### PR TITLE
Fixed radians/degrees bug in figure header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # mtuq
 
-MTUQ provides *m*oment *t*ensor estimates and *u*ncertainty *q*uantification from broadband seismic data.  
+MTUQ provides *m*oment *t*ensor estimates and *u*ncertainty *q*uantification from broadband seismic data, along with
 
-The package reproduces the functionality of [ZhaoHelmberger1994] and [ZhuHelmberger1996] and has been [tested against](https://github.com/uafgeotools/mtuq/blob/master/tests/benchmark_cap_vs_mtuq.py) their Perl/C codes.
-
-Additionally, MTUQ provides
-
-- a flexible Python design, borrowing from [ObsPy] and [Instaseis] data structures
-- C-accelerated, (optionally) MPI-parallelized misfit function evaluation
 - ability to interface with modern solvers, including AxiSEM and SPECFEM3D
+- GMT wrappers for uncertainty visualization on the eigenvalue lune
+- C-accelerated, MPI-parallelized misfit function evaluation
+- a flexible Python design borrowing from [ObsPy] and [Instaseis] data structures
+
+The package has been [tested against](https://github.com/uafgeotools/mtuq/blob/master/tests/benchmark_cap_vs_mtuq.py) community Perl/C codes.
+
 
 
 

--- a/docs/user_guide/01.rst
+++ b/docs/user_guide/01.rst
@@ -1,10 +1,8 @@
 Learning Python and ObsPy
 =========================
 
-MTUQ is written in Python, an interpreted language with a strong scientific ecosystem.  
+To avoid reinventing the wheel, MTUQ makes extensive use of `ObsPy <https://github.com/obspy/obspy/wiki>`_, a widely-used Python package for seismology.
 
-One of the most widely-used Python packages for seismology is `ObsPy <https://github.com/obspy/obspy/wiki>`_.  To avoid reinventing the wheel, MTUQ makes extensive use of ObsPy data structures.
-
-An excellent place to start learning about Python or ObsPy is the `ObsPy tutorial <http://docs.obspy.org/tutorial/index.html>`_.
+An excellent place to start learning about Python and ObsPy is the `ObsPy tutorial <http://docs.obspy.org/tutorial/index.html>`_.
 
 

--- a/docs/user_guide/03.rst
+++ b/docs/user_guide/03.rst
@@ -2,15 +2,24 @@
 Acquiring Green's functions
 ===========================
 
-The response of a medium to an impulsive source is called a Green's function.  This page explains how Green's functions are used in source inversions.   It describes the types of Green's functions supported by MTUQ and how they can be acquired.
+The response of a medium to an impulsive source is called a Green's function.  This page explains how Green's functions are used in source inversions.   It describes the types of Green's functions supported by MTUQ and how these types can be obtained.
 
 
 Role of Green's functions
 -------------------------
 
-In source inversions, the main reason Green's functions are useful is that they provide computaional savings.  It is usually cheaper to generate synthetics by summing Green's functions than it is to perform many individual wavefield simulations.
+As the response of a medium to a simple impulsive source, Green's functions can be combined to obtain synthetics from more complex sources.
 
-In MTUQ, `GreensTensor <https://uafgeotools.github.io/mtuq/library/generated/mtuq.GreensTensor.html>`_ objects provide access to the full set of Green's functions needed to describe the medium response between a given station and origin.
+Green's functions are useful because they provide computaional savings.  It is almost always cheaper to work with precomputed Green's functions than it is to perform on-the-fly wavefield simulations.
+
+
+`GreensTensor` objects
+----------------------
+
+In MTUQ, `GreensTensor` objects provide access to the full set of Green's functions needed to describe the medium response between a given station and origin.  Of particular note, the `get_synthetics` method accepts a `MomentTensor` or other seismic source, and returns a set of traces representing the response at the given station.  The full set of `GreensTensor`  methods is described in the `library reference <https://uafgeotools.github.io/mtuq/library/generated/mtuq.GreensTensor.html>`_
+
+The following sections describe how Green's functions from external solvers can be downloaded or computed and used to generate MTUQ `GreensTensor` objects.
+
 
 
 
@@ -19,13 +28,21 @@ Downloading precomputed Green's functions
 
 One of the easiest ways to acquire Green's functions is to download them using `syngine <http://ds.iris.edu/ds/products/syngine/>`_.  The syngine webservice makes Green's functions available from the following 1D Earth models: PREM, AK135, and iasp91.
 
-At the time this documentation was written, one limitation of syngine is that Green's functions are availble from only a handful of Earth models.  Another limitation is that syngine provides Green's functions only at specific stations, not over the whole Earth.  If these limitations affect your use case, an alternative is to compute your own Green's function database, as described below.
+One limitation of syngine is that Green's functions are availble from only a handful of Earth models.  Another limitation is that syngine provides Green's functions only at specific stations, not over the whole Earth.  If these limitations affect your use case, an alternative is to compute your own Green's function database, as described below.
+
+To download AK135 Green's functions and generate MTUQ `GreenTensor` objects:
+
+.. code ::
+
+   from mtuq import download_greens_functions
+   greens_tensors = download_greens_functions(model="ak135f_2s")
+
 
 
 Computing Green's functions from 1D Earth models
 ------------------------------------------------
 
-MTUQ currently supports 1D Green's functions from two solvers: AxiSEM (preferred) and FK.
+MTUQ currently supports 1D Green's functions formats: AxiSEM (preferred) and FK.
 
 `AxiSEM <https://github.com/geodynamics/axisem>`_ simulates wave propagation in radially-symmeric Earth models using a spectral-element method.  To generate synthetics in a format MTUQ natively supports, follow the instructions for in the `AxiSEM user manual <https://geodynamics.org/cig/software/axisem/axisem-manual.pdf>`_  under "Output wavefields in NetCDF formated needed by instaseis."  AxiSEM NetCDF files can be used to retrieve vertical, radial, and transverse  displacement in units of m*(N-m)^-1.
 

--- a/docs/user_guide/04.rst
+++ b/docs/user_guide/04.rst
@@ -1,11 +1,4 @@
 
-Data processing
-===============
+Running and modifying examples
+==============================
 
-Filtering, windowing and other data processing operations are essential for meaningful goodness-of-fit measurements.  This page describes the default data processing utility included in MTUQ.
-
-
-Writing your own data processing functions
-------------------------------------------
-
-Users have nearly complete freedom

--- a/mtuq/graphics/header.py
+++ b/mtuq/graphics/header.py
@@ -218,7 +218,7 @@ def _focal_mechanism(lune_dict):
     strike = lune_dict['kappa']
 
     try:
-        dip = np.arccos(lune_dict['h'])
+        dip = np.degrees(np.arccos(lune_dict['h']))
     except:
         dip = lune_dict['theta']
 


### PR DESCRIPTION
The dip of the focal plane was being displayed in radians.  Now it is being displayed in degrees, like all the other entries.