### PR TITLE
Slight modification to waveform.py

### DIFF
--- a/mtuq/graphics/waveform.py
+++ b/mtuq/graphics/waveform.py
@@ -296,8 +296,8 @@ def plot_data_greens(filename,
     except:
         event_name = filename.split('.')[0]
 
-    model = _get_tag(greens_bw[0].tags, 'model')
-    solver = _get_tag(greens_bw[0].tags, 'solver')
+    model = _get_tag(greens_sw[0].tags, 'model')
+    solver = _get_tag(greens_sw[0].tags, 'solver')
 
     if 'header' in kwargs:
         header = kwargs.pop('header')


### PR DESCRIPTION
model and solver are now extracted from greens_sw instead of greens_bw, as the program allows the bw dataset to be empty.