### PR TITLE
calculate and store normalized cc coefficient

### DIFF
--- a/mtuq/misfit/waveform/level0.py
+++ b/mtuq/misfit/waveform/level0.py
@@ -67,7 +67,7 @@ def misfit(data, greens, sources, norm, time_shift_groups,
                 corr[:] = 0.
                 for _k in indices:
                     corr += np.correlate(s[_k].data, d[_k].data, 'valid')
-
+                
                 npts_shift = padding_left - corr.argmax()
                 time_shift = npts_shift*dt - (time_shift_min + time_shift_max)
 
@@ -97,9 +97,21 @@ def misfit(data, greens, sources, norm, time_shift_groups,
                         values[_i] += value
 
                     if set_attributes:
+                        Ns = np.dot(s[_k].data,s[_k].data)**0.5
+                        Nd = np.dot(d[_k].data,d[_k].data)**0.5
+
                         s[_k].attrs = AttribDict()
 
                         s[_k].attrs.misfit = value
+
+                        s[_k].attrs.cc_max = corr.max()
+                        
+                        if Ns*Nd > 0:
+                            max_cc = np.correlate(s[_k].data,d[_k].data,'valid').max()
+                            s[_k].attrs.normalized_cc_max = max_cc/(Ns*Nd)
+                        else:
+                            s[_k].attrs.normalized_cc_max = np.nan
+
                         s[_k].attrs.time_shift = time_shift
                         s[_k].attrs.start = start
                         s[_k].attrs.stop = stop


### PR DESCRIPTION
Calculate the normalized cross-correlation coefficient and store it in the attribute dictionary for later use in post-processing graphics. The calculation is done the same [here](https://github.com/uafgeotools/mtuq/blob/master/mtuq/graphics/waveforms.py#L543).