### PR TITLE
Fixed force plot.

### DIFF
--- a/mtuq/graphics/uq/_gmt.py
+++ b/mtuq/graphics/uq/_gmt.py
@@ -12,7 +12,7 @@ from six import string_types
 
 
 
-def _plot_lune_gmt(filename, lon, lat, values, best_vw=None, lune_array=None, 
+def _plot_lune_gmt(filename, lon, lat, values, best_vw=None, lune_array=None,
     **kwargs):
 
     if _nothing_to_plot(values):
@@ -48,8 +48,8 @@ def _plot_force_gmt(filename, phi, h, values, best_force=None, **kwargs):
 
     data =  _parse_data(lon, lat, values)
 
-    _call(fullpath('mtuq/graphics/uq/_gmt/plot_force'), 
-       filename, lon, lat, values, supplemental_data=None,
+    _call(fullpath('mtuq/graphics/uq/_gmt/plot_force'),
+       filename, data, supplemental_data=None,
        marker_coords=_parse_force(best_force), **kwargs)
 
 
@@ -67,7 +67,7 @@ def _plot_latlon_gmt(filename, lon, lat, values, best_latlon=None, lune_array=No
 
 
 def _call(shell_script, filename, data, supplemental_data=None,
-    title='', colormap='viridis', flip_cpt=False, colorbar_type=1, 
+    title='', colormap='viridis', flip_cpt=False, colorbar_type=1,
     colorbar_label='', marker_coords=None, marker_type=0):
 
     #
@@ -414,5 +414,3 @@ def _float_to_str(val):
 def _savetxt(filename, *args, fmt='%.6e'):
     # TODO - can GMT accept virtual files?
     np.savetxt(filename, np.column_stack(args), fmt=fmt)
-
-

--- a/mtuq/io/clients/syngine.py
+++ b/mtuq/io/clients/syngine.py
@@ -3,9 +3,10 @@ import obspy
 import numpy as np
 
 from obspy.core import Stream
-from mtuq.greens_tensor.syngine import GreensTensor 
+from mtuq.greens_tensor.syngine import GreensTensor
 from mtuq.io.clients.base import Client as ClientBase
 from mtuq.util.signal import resample
+from mtuq.util import unzip
 from mtuq.util.syngine import download_unzip_mt_response, download_force_response,\
      resolve_model,\
      GREENS_TENSOR_FILENAMES, SYNTHETICS_FILENAMES
@@ -14,13 +15,13 @@ from mtuq.util.syngine import download_unzip_mt_response, download_force_respons
 
 class Client(ClientBase):
     """ Syngine web service client
-        
+
     .. rubric:: Usage
 
     To instantiate a syngine client, supply the name of an Earth model from one
-    one of the available Earth models listed at 
+    one of the available Earth models listed at
     http://ds.iris.edu/ds/products/syngine/#models
-        
+
     .. code::
 
         from mtuq.io.clients.syngine import Client
@@ -29,18 +30,18 @@ class Client(ClientBase):
     Then the client can be used to download GreensTensors:
 
     .. code::
-        
+
         greens_tensors = db.get_greens_tensors(stations, origin)
-            
+
 
     .. note::
 
         Syngine is an webservice that provides Green's functions and synthetic
-        seismograms for download as compressed SAC files. 
+        seismograms for download as compressed SAC files.
 
     """
 
-    def __init__(self, path_or_url=None, model=None, 
+    def __init__(self, path_or_url=None, model=None,
                  include_mt=True, include_force=False):
 
         if not path_or_url:
@@ -129,7 +130,7 @@ class Client(ClientBase):
             'solver:%s' % 'syngine',
              ]
 
-        return GreensTensor(traces=[trace for trace in stream], 
+        return GreensTensor(traces=[trace for trace in stream],
             station=station, origin=origin, tags=tags,
             include_mt=self.include_mt, include_force=self.include_force)
 
@@ -148,7 +149,7 @@ def download_greens_tensors(stations=[], origins=[], model='', verbose=False, **
 
     ``stations`` (list of `mtuq.Station` objects):
     Stations for which Green's functions will be downloaded
-    
+
 
     ``origins`` (list of `mtuq.Origin` objects):
     Origins for which Green's functions will be downloaded
@@ -161,6 +162,3 @@ def download_greens_tensors(stations=[], origins=[], model='', verbose=False, **
     """
     client = Client(model=model, **kwargs)
     return client.get_greens_tensors(stations, origins, verbose=verbose)
-
-
-


### PR DESCRIPTION
With the implementation of a unified _call() function in the gmt plotting utils, a formating error was introduced in the force plot (we will also have to correct the vw gmt plotting function sometime down the line as well). -- It was still using the "lon, lat, values" format instead of the expected "data" array.

I made some minimal modification in order to fix the misift force plot.