### PR TITLE
grid for deviatoric example

### DIFF
--- a/mtuq/grid/__init__.py
+++ b/mtuq/grid/__init__.py
@@ -5,7 +5,7 @@ from xarray import DataArray
 
 from mtuq.grid.base import Grid, UnstructuredGrid
 
-from mtuq.grid.moment_tensor import FullMomentTensorGridSemiregular, FullMomentTensorGridRandom, FullMomentTensorPlottingGrid,\
+from mtuq.grid.moment_tensor import FullMomentTensorGridSemiregular, FullMomentTensorGridRandom, FullMomentTensorPlottingGrid, DeviatoricGridSemiregular, \
     DoubleCoupleGridRegular, DoubleCoupleGridRandom
 
 from mtuq.grid.force import ForceGridRegular, ForceGridRandom

--- a/mtuq/grid/moment_tensor.py
+++ b/mtuq/grid/moment_tensor.py
@@ -120,6 +120,23 @@ def FullMomentTensorPlottingGrid(magnitudes=[1.], npts_per_axis=11, tightness=0.
         coords=(rho, v, w, kappa, sigma, h),
         callback=to_mt)
 
+def DeviatoricGridSemiregular(magnitudes=[1.], npts_per_axis=20, tightness=0.8):
+    """ Deviatoric grid. See FullMomentTensorGridSemiregular for details
+
+    """
+    v, w = semiregular_grid(npts_per_axis, 2*npts_per_axis, tightness)
+    w = 0
+
+    kappa = regular(0., 360, npts_per_axis)
+    sigma = regular(-90., 90., npts_per_axis)
+    h = regular(0., 1., npts_per_axis)
+    rho = list(map(to_rho, asarray(magnitudes)))
+
+    return Grid(
+        dims=('rho', 'v', 'w', 'kappa', 'sigma', 'h'),
+        coords=(rho, v, w, kappa, sigma, h),
+        callback=to_mt)
+
 
 def DoubleCoupleGridRandom(magnitudes=[1.], npts=50000):
     """ Double-couple moment tensor grid with randomly-spaced values
@@ -156,7 +173,7 @@ def DoubleCoupleGridRandom(magnitudes=[1.], npts=50000):
         dims=('rho', 'v', 'w', 'kappa', 'sigma', 'h'),
         coords=(rho, v, w, kappa, sigma, h),
         callback=to_mt)
-
+    
 
 def DoubleCoupleGridRegular(magnitudes=[1.], npts_per_axis=40):
     """ Double-couple moment tensor grid with regularly-spaced values


### PR DESCRIPTION
We had a request for a deviatoric search during the MTUQ 2022 workshop. This pull request simply sets w=0 in a copy of the FullMomentTensorGridSemiregular and updates __init__.py. 