### PR TITLE
Polarity misfit

### DIFF
--- a/examples/GridSearch.FullMomentTensor_polarity.py
+++ b/examples/GridSearch.FullMomentTensor_polarity.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+
+import os
+import numpy as np
+from mtuq.misfit import Misfit, PolarityMisfit
+
+from mtuq import read, open_db, download_greens_tensors
+from mtuq.event import Origin
+from mtuq.graphics import plot_data_greens2, plot_beachball, plot_misfit_lune, beachball_pygmt
+from mtuq.grid import FullMomentTensorGridSemiregular
+from mtuq.grid_search import grid_search
+from mtuq.misfit import Misfit, PolarityMisfit
+from mtuq.process_data import ProcessData
+from mtuq.util import fullpath, merge_dicts, save_json
+from mtuq.util.cap import parse_station_codes, Trapezoid
+
+
+
+if __name__=='__main__':
+    #
+    # Carries out grid search over all moment tensor parameters
+    #
+    # USAGE
+    #   mpirun -n <NPROC> python GridSearch.FullMomentTensor.py
+    #
+
+
+    path_data=    fullpath('data/examples/20090407201255351/*.[zrt]')
+    path_weights= fullpath('data/examples/20090407201255351/weights.dat')
+    event_id=     '20090407201255351'
+    model=        'ak135'
+
+
+    #
+    # For our objective function, we will use a finite count of mismatching
+    # polarity orientations
+    #
+
+    pmisfit = PolarityMisfit(taup_model=model, polarity_keyword='user3')
+
+
+    #
+    # User-supplied weights control how much each station contributes to the
+    # objective function. Weight file can contain polarity information.
+    #
+
+    station_id_list = parse_station_codes(path_weights)
+
+
+    #
+    # Next, we specify the moment tensor grid and source-time function
+    #
+
+    grid = FullMomentTensorGridSemiregular(
+        npts_per_axis=10,
+        magnitudes=[4.4])
+
+
+    #
+    # Origin time and location will be fixed. For an example in which they
+    # vary, see examples/GridSearch.DoubleCouple+Magnitude+Depth.py
+    #
+    # See also Dataset.get_origins(), which attempts to create Origin objects
+    # from waveform metadata
+    #
+
+    origin = Origin({
+        'time': '2009-04-07T20:12:55.000000Z',
+        'latitude': 61.454200744628906,
+        'longitude': -149.7427978515625,
+        'depth_in_m': 33033.599853515625,
+        })
+
+
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+
+
+    #
+    # The main I/O work starts now
+    #
+
+    if comm.rank==0:
+        print('Reading data...\n')
+        data = read(path_data, format='sac',
+            event_id=event_id,
+            station_id_list=station_id_list,
+            tags=['units:cm', 'type:velocity'])
+
+        data.sort_by_distance()
+        stations = data.get_stations()
+
+        print('Reading Greens functions...\n')
+        greens = download_greens_tensors(stations, origin, model)
+
+    else:
+        stations = None
+        data = None
+        greens = None
+
+    stations = comm.bcast(stations, root=0)
+    data = comm.bcast(data, root=0)
+    greens = comm.bcast(greens, root=0)
+
+    #
+    # The main computational work starts now
+    #
+
+    # Picked polarity values. len(polarity_input) = len(data)
+    polarity_input = np.array([-1, -1, -1, 1, 1, 0, 1, 1, -1, 1, 1, 1, 0 ,1, 1, 1, -1, 1, 1, 0])
+
+    # Polulating SAC headers to test mtuq.Database input
+    for i in range(len(data)):
+        data[i][0].stats.sac['user3'] = polarity_input[i]
+
+    # Polulating SAC headers to test mtuq.GreensTensorList input
+    for i in range(len(greens)):
+        greens[i][0].stats.sac['user3'] = polarity_input[i]
+
+    if comm.rank==0:
+        print('Evaluating polarity misfit...\n')
+
+    # Using an array as input
+    results = grid_search(
+    polarity_input, greens, pmisfit, origin, grid)
+
+    # Using mtuq.Dataset as input
+    results = grid_search(
+    data, greens, pmisfit, origin, grid)
+
+    # Using mtuq.GreensTensorList as input
+    results = grid_search(
+    greens, greens, pmisfit, origin, grid)
+
+    # Using weight file path as input
+    # This one relies on appending `/+1` or `/-1` after the station ID in the CAP weight file in `path_weights`.
+    # results = grid_search(
+    # path_weights, greens, pmisfit, origin, grid)
+
+
+    if comm.rank==0:
+
+        #
+        # Generate figures and save results
+        #
+
+        print('Generating figures...\n')
+
+        plot_misfit_lune(event_id+'FMT_misfit.png', results)
+
+        print('Saving results...\n')
+
+        # save misfit surface
+        results.save(event_id+'FMT_misfit.nc')
+
+
+        # This search will have several matching moment tensor.
+        # For illustration sake, we pick one of the minimum solution at random
+        # from the list of best fitting moment tensor and plot it.
+        values = results.values.reshape(len(grid))
+        min_indexes = []
+        min_value = min(values)
+        import random
+
+        # List all minimum values indexes
+        for i in range(len(values)):
+            if values[i] == min_value:
+                min_indexes.append(i)
+        # Select one at random
+        random_index = random.randrange(len(min_indexes))
+        random_value = min_indexes[random_index]
+        # Then plot it
+        beachball_pygmt('polarity.pdf', path_weights, greens, grid.get(random_value))
+
+        print('\nFinished\n')

--- a/examples/GridSearch.FullMomentTensor_polarity.py
+++ b/examples/GridSearch.FullMomentTensor_polarity.py
@@ -52,7 +52,7 @@ if __name__=='__main__':
     #
 
     grid = FullMomentTensorGridSemiregular(
-        npts_per_axis=10,
+        npts_per_axis=15,
         magnitudes=[4.4])
 
 
@@ -120,6 +120,7 @@ if __name__=='__main__':
     if comm.rank==0:
         print('Evaluating polarity misfit...\n')
 
+
     # Using an array as input
     results = grid_search(
     polarity_input, greens, pmisfit, origin, grid)
@@ -170,6 +171,6 @@ if __name__=='__main__':
         random_index = random.randrange(len(min_indexes))
         random_value = min_indexes[random_index]
         # Then plot it
-        beachball_pygmt('polarity.pdf', path_weights, greens, grid.get(random_value))
+        beachball_pygmt('polarity.pdf', polarity_input, greens, grid.get(random_value))
 
         print('\nFinished\n')

--- a/mtuq/graphics/beachball.py
+++ b/mtuq/graphics/beachball.py
@@ -125,10 +125,10 @@ def calculate_takeoff_angle(taup, source_depth_in_km, **kwargs):
             phases += [arrival.phase.name]
 
         if 'p' in phases:
-            return arrivals[phases.index('p')].incident_angle
+            return arrivals[phases.index('p')].takeoff_angle
 
         elif 'P' in phases:
-            return arrivals[phases.index('P')].incident_angle
+            return arrivals[phases.index('P')].takeoff_angle
         else:
             raise Excpetion
 

--- a/mtuq/graphics/beachball.py
+++ b/mtuq/graphics/beachball.py
@@ -5,8 +5,8 @@
 
 # To correctly plot focal mechanims, MTUQ uses Generic Mapping Tools (GMT).
 
-# If GMT >=6.0.0 executables are not found on the system path, MTUQ falls 
-# back to ObsPy. As described in the following GitHub issue, ObsPy 
+# If GMT >=6.0.0 executables are not found on the system path, MTUQ falls
+# back to ObsPy. As described in the following GitHub issue, ObsPy
 # focal mechanism plots suffer from  plotting artifacts:
 
 # https://github.com/obspy/obspy/issues/2388
@@ -24,6 +24,7 @@ from mtuq.graphics._gmt import _parse_filetype, _get_format_arg, _safename,\
     exists_gmt, gmt_major_version
 from mtuq.graphics._pygmt import exists_pygmt
 from mtuq.util import asarray, to_rgb, warn
+from mtuq.util.polarity import calculate_takeoff_angle
 from obspy.geodetics import gps2dist_azimuth, kilometers2degrees
 from obspy.geodetics import kilometers2degrees as _to_deg
 from obspy.taup import TauPyModel
@@ -115,28 +116,6 @@ def plot_polarities(filename, polarities, mt, stations, origin, **kwargs):
     raise NotImplementedError
 
 
-
-def calculate_takeoff_angle(taup, source_depth_in_km, **kwargs):
-    try:
-        arrivals = taup.get_travel_times(source_depth_in_km, **kwargs)
-
-        phases = []
-        for arrival in arrivals:
-            phases += [arrival.phase.name]
-
-        if 'p' in phases:
-            return arrivals[phases.index('p')].takeoff_angle
-
-        elif 'P' in phases:
-            return arrivals[phases.index('P')].takeoff_angle
-        else:
-            raise Excpetion
-
-    except:
-        # if taup fails, use dummy takeoff angle
-        return None
-
-
 #
 # GMT implementation
 #
@@ -146,7 +125,7 @@ GMT_PROJECTION = '-Jm0/0/5c'
 
 
 def _plot_beachball_gmt(filename, mt, stations, origin,
-    taup_model='ak135', add_station_markers=True, add_station_labels=True, 
+    taup_model='ak135', add_station_markers=True, add_station_labels=True,
     fill_color='gray', marker_color='black'):
 
 
@@ -250,7 +229,7 @@ def _write_stations(filename, stations, origin, taup_model):
                 station.longitude)
 
             takeoff_angle = calculate_takeoff_angle(
-                taup, 
+                taup,
                 origin.depth_in_m/1000.,
                 distance_in_degree=_to_deg(distance_in_m/1000.),
                 phase_list=['p', 'P'])
@@ -352,5 +331,3 @@ def _plot_polarities_pygmt():
 
     # case 4 - observed negative, synthetic positive
     _pygmt_polar()
-
-

--- a/mtuq/graphics/beachball_pygmt.py
+++ b/mtuq/graphics/beachball_pygmt.py
@@ -25,17 +25,22 @@ def beachball_pygmt(filename, polarity_input, greens, mt, plot_all=False, displa
     ``filename`` (`str`):
     Name of output image file
 
-    ``data`` (`mtuq.DataSet`):
-    mtuq Dataset with valid sac header
+    ``polarity_input`` (`list`, `numpy.ndarray`, `mtuq.dataset.Dataset`,
+    `mtuq.greens_tensor.base.GreensTensorList, `str`):
+    See mtuq.misfit.polarity.PolarityMisfit() and
+    mtuq.util.polarity.extract_polarity() for a complete set of instructions. Polarity inputs should only contains [1, 0, -1] values.
+
+    ``greens`` (mtuq.GreensTensorList): green's function list required to compute takeoff angles.
 
     ``mt`` (`mtuq.MomentTensor`):
     Moment tensor object
 
-    Warning : Implemented and tested with PyGMT v0.3.1, which is still in early developpment. It is possible that the code might break some time in the future, as nerwer versions of the code are rolled-out.
+    Warning : Implemented and tested with PyGMT v0.3.1, which is still in early
+    developpment. It is possible that the code might break some time in the
+    future, as nerwer versions of the code are rolled-out.
 
-    This plotting function presuppose that the data is a valid mtuq.DataSet whith a sac header containing the station azimuth in the `az` key, the takeoff_angle in the key `user3` and the picked polarity in the key `user5`
-
-    TODO: This function will benefit from having a different way of handling polarity than with the sac header used as of right now. This will enable easier usage for user that won't be using pysep to fetch the data.
+    This plotting function presuppose that greens is a mtuq.GreensTensorList
+    whith a valid SAC header containing the station.azimuth key. The takeoff angles is computed on the fly using obspy.taup or by reading FK Green's tensor SAC files header ('user1' key).
     """
     import pygmt
     from pygmt.helpers import build_arg_string, use_alias
@@ -49,7 +54,7 @@ def beachball_pygmt(filename, polarity_input, greens, mt, plot_all=False, displa
              convention="mt", G='grey50', spec=focal_mechanism, N=False, M=True)
 
 
-    polarities = extract_polarity(polarity_input)
+    polarities = extract_polarity(polarity_input, polarity_keyword=polarity_keyword)
     takeoff_angles = extract_takeoff_angle(greens,taup_model=taup_model)
     azimuths = [sta.azimuth for sta in greens]
 
@@ -158,7 +163,7 @@ def beachball_pygmt(filename, polarity_input, greens, mt, plot_all=False, displa
     _pygmt_polar(down_unmatched_data, symbol='i0.40c', ext_fill='red')
     # If `plot_all` is True, will plot the unpicked stations as black crosses over the beachball plot
     if not plot_all is False:
-        _pygmt_polar(unpicked_data, symbol='x0.40c', comp_outline='black', ext_outline='black')
+        _pygmt_polar(unpicked_data, symbol='x0.40c', comp_outline='black')
 
     # fig.show(dpi=300, method="external")
     fig.savefig(filename, show=display_plot)

--- a/mtuq/misfit/polarity.py
+++ b/mtuq/misfit/polarity.py
@@ -11,7 +11,7 @@ from mtuq.util.polarity import extract_polarity, extract_takeoff_angle
 class PolarityMisfit(object):
     """ Polarity misfit function
 
-    Compares first-motion polarities between data and synthetics
+    Evaluates first motion polarity by comparing observed and predicted first-motion polarities.
 
     .. rubric:: Usage
 
@@ -20,15 +20,39 @@ class PolarityMisfit(object):
     .. code::
 
         function_handle = Misfit(**parameters)
-        values = function_handle(data, greens, sources)
+        values = function_handle(polarity_input, greens, sources)
+
+    In the first step, the user may supply optional parameters such as the sac
+    header keyword that stores the polarity inputs or the velocity model used
+    to compute takeoff angles (see below for detailed argument descriptions).
+
+    In the second step, the user supplies the polarity inputs (list, numpy
+    array, mtuq Dataset or Green's function list, CAP weight files), Green's
+    functions, and sources.
+    Theoretical first motion polarities are then generated and compared with observed first motions, and a NumPy array of misfit values is returned of
+    the same length as `sources`.
+
+
+    .. rubric:: Parameters
+
+    ``polarity_keyword`` (`str`): SAC header field where observed polarity is
+    stored. Used when the polarity input type is mtuq.Dataset or
+    mtuq.GreensTensorList (for ex: 'user3', would point to
+    trace.stats.sac['user3'] entry in the SAC header).
+
+    ``taup_model`` (`str`): Valid obspy taup model name, used to compute takeoff angles. If not a default obspy.taup model, taup_model should be a path pointing to a valid .npz velocity model file.
+
+    .. note::
+
+    *Convention* : Positive vertical motion should be encoded as +1 and negative vertical motion should be encoded as -1 and unpicked data as 0.
+    (integer values [1, 0, -1])
 
     """
 
     def __init__(self, polarity_keyword=None, taup_model='ak135'):
         """ Function handle constructor
-        Will be used to manage different kind of polarity input (np.array, pandas dataframe, data with sac header.)
-
-        Currently only used to create the polarity misfit object.
+        Pre-set optional arguments for custom polarity misfit inputs (sac
+        header to read polarity from, velocity model to compute takeoff angles).
 
         """
 

--- a/mtuq/misfit/polarity.py
+++ b/mtuq/misfit/polarity.py
@@ -28,13 +28,18 @@ class PolarityMisfit(object):
 
     In the second step, the user supplies the polarity inputs (list, numpy
     array, mtuq Dataset or Green's function list, CAP weight files), Green's
-    functions, and sources.
-    Theoretical first motion polarities are then generated and compared with observed first motions, and a NumPy array of misfit values is returned of
+    functions, and sources grid. This function presuppose that greens is a
+    mtuq.GreensTensorList whith a valid SAC header containing the
+    station.azimuth key.
+    Theoretical first motion polarities are then generated and compared with
+    observed first motions, and a NumPy array of misfit values is returned of
     the same length as `sources`.
 
     When the polarity_input is a mtuq.Dataset or a mtuq.GreensTensorList, the
     picked polarity info should be written in the header of the first trace
-    of the stream of each station. The "polarity_keyword" will then have to be defined to point toward the right key in the SAC header of each station's first trace.
+    of the stream of each station. The "polarity_keyword" will then have to be
+    defined to point toward the right key in the SAC header of each station's
+    first trace.
 
     .. example:
 
@@ -51,14 +56,20 @@ class PolarityMisfit(object):
     mtuq.GreensTensorList (for ex: 'user3', would point to
     trace.stats.sac['user3'] entry in the SAC header).
 
-    ``taup_model`` (`str`): Valid obspy taup model name, used to compute takeoff angles. If not a default obspy.taup model, taup_model should be a path pointing to a valid .npz velocity model file.
+    ``taup_model`` (`str`): Valid obspy taup model name, used to compute
+    takeoff angles. If not a default obspy.taup model, taup_model should be a
+    path pointing to a valid .npz velocity model file.
 
     .. note::
 
-    *Convention* : Positive vertical motion should be encoded as +1 and negative vertical motion should be encoded as -1 and unpicked data as 0.
+    *Convention* : Positive vertical motion should be encoded as +1 and
+    negative vertical motion should be encoded as -1 and unpicked data as 0.
     (integer values [1, 0, -1])
 
-    *Using FK* : If the Green's function were generated using FK, the takeoff angle should already be pre-written in the SAC files. The takeoff angle will thus be read from the 'user1' SAC header field of the Green's function, instead of being computed on the fly using obspy.taup function. 
+    *Using FK* : If the Green's function were generated using FK, the takeoff
+    angle should already be pre-written in the SAC files. The takeoff angle
+    will thus be read from the 'user1' SAC header field of the Green's
+    function, instead of being computed on the fly using obspy.taup function.
 
     """
 

--- a/mtuq/misfit/polarity.py
+++ b/mtuq/misfit/polarity.py
@@ -19,7 +19,7 @@ class PolarityMisfit(object):
 
     .. code::
 
-        function_handle = Misfit(**parameters)
+        function_handle = PolarityMisfit(**parameters)
         values = function_handle(polarity_input, greens, sources)
 
     In the first step, the user may supply optional parameters such as the sac
@@ -32,6 +32,17 @@ class PolarityMisfit(object):
     Theoretical first motion polarities are then generated and compared with observed first motions, and a NumPy array of misfit values is returned of
     the same length as `sources`.
 
+    When the polarity_input is a mtuq.Dataset or a mtuq.GreensTensorList, the
+    picked polarity info should be written in the header of the first trace
+    of the stream of each station. The "polarity_keyword" will then have to be defined to point toward the right key in the SAC header of each station's first trace.
+
+    .. example:
+
+    `pmisfit = PolarityMisfit(polarity_keyword='user3')`
+
+    will seek a +1, 0 or -1 value in
+    `Stream[0].stats.sac['user3']`
+    for each station stream in the mtuq.Dataset or mtuq.GreensTensorList
 
     .. rubric:: Parameters
 
@@ -46,6 +57,8 @@ class PolarityMisfit(object):
 
     *Convention* : Positive vertical motion should be encoded as +1 and negative vertical motion should be encoded as -1 and unpicked data as 0.
     (integer values [1, 0, -1])
+
+    *Using FK* : If the Green's function were generated using FK, the takeoff angle should already be pre-written in the SAC files. The takeoff angle will thus be read from the 'user1' SAC header field of the Green's function, instead of being computed on the fly using obspy.taup function. 
 
     """
 

--- a/mtuq/misfit/polarity.py
+++ b/mtuq/misfit/polarity.py
@@ -1,8 +1,12 @@
 
 import numpy as np
 
+import mtuq
+from mtuq.util.math import radiation_coef
 from mtuq.util import Null, iterable, warn
-
+from mtuq.misfit.waveform.level2 import _to_array
+from obspy.taup import TauPyModel
+from mtuq.util.polarity import extract_polarity, extract_takeoff_angle
 
 class PolarityMisfit(object):
     """ Polarity misfit function
@@ -20,7 +24,7 @@ class PolarityMisfit(object):
 
     """
 
-    def __init__(self):
+    def __init__(self, polarity_keyword=None, taup_model='ak135'):
         """ Function handle constructor
         Will be used to manage different kind of polarity input (np.array, pandas dataframe, data with sac header.)
 
@@ -28,74 +32,38 @@ class PolarityMisfit(object):
 
         """
 
-        print('Doing nothing right now')
+        self.polarity_keyword = polarity_keyword
+        self.taup_model = taup_model
 
+        print('Setting up default parameters')
 
-    def __call__(self, data, greens, sources, progress_handle=Null(),
-        set_attributes=False, polarity_keyword = 'user5'):
+    def __call__(self, polarity_input, greens, sources, progress_handle=Null(),
+                 set_attributes=False):
         """ Evaluates polarity misfit on given data.
 
-
         """
-        # First checking that sac headers are set in odrder to run the function
-        # if polarity_keyword not None:
-        if all(d[0].stats.sac != None for d in data):
-            polarities = [d[0].stats.sac[polarity_keyword] for d in data]
-        else:
-            print('SAC format expected')
-            raise NotImplementedError
 
         # Preallocate list containing source vector for faster computation.
-        source_vector_list = np.array([source.as_vector() for source in sources])
-
+        source_vector_list = _to_array(sources)
         # Create the array to store polarity misfit values.
         values = np.zeros((len(sources), 1))
+
         # Extracting measured polarities,  as a numpy array
-        observed_polarities = np.asarray([sta[0].stats.sac[polarity_keyword] for sta in data])
-        # List takeoff_angle and azimuth out of the provided data
-        takeoff_angle = [sta[0].stats.sac['user3'] for sta in data]
-        azimuth = [sta[0].stats.sac['az'] for sta in data]
+        observed_polarities = extract_polarity(polarity_input)
+
+        takeoff_angles = extract_takeoff_angle(greens, taup_model=self.taup_model)
+
+        azimuths = [sta.azimuth for sta in greens]
 
         # Compute a NSOURCESxNSTATIONS array for quick misfit evaluation.
-        predicted_polarity = np.asarray([radiation_coef(source_vector_list, takeoff_angle[i], azimuth[i]) for i in range(len(data))])
+        predicted_polarity = np.asarray(
+            [radiation_coef(source_vector_list, takeoff_angles[i], azimuths[i]) for i in range(len(observed_polarities))])
 
         # Misfit evaluation
         # values = (|obs|*calc) - obs
         # ((|obs|*calc) is used to filter out the un-picked station polarities)
-        values = np.sum(np.abs(predicted_polarity.T*np.abs(observed_polarities)-observed_polarities), axis=1)
+        values = np.sum(np.abs(predicted_polarity.T *
+                               np.abs(observed_polarities)-observed_polarities), axis=1)/2
 
         # returns a NSOURCESx1 np array
         return np.array([values]).T
-
-
-def radiation_coef(mt_array, takeoff_angle, azimuth):
-    """ Computes P-wave radiation coefficient from a collection of sources (2D np.array with source parameter vectors), and the associated takeoff_angle and azimuth for a given station. The radiation coefficient is computed in mtuq orientation conventions.
-
-    Based on Aki & Richards, Second edition (2009), eq. 4.88, p. 108
-    """
-    # Check if mt_array is a 2D array, and make it 2D if not.
-    if len(mt_array.shape) == 1:
-        mt_array = np.array([mt_array])
-
-    alpha = np.deg2rad(takeoff_angle)
-    az = np.deg2rad(azimuth)
-    dir = np.zeros((len(mt_array),3))
-    sth = np.sin(alpha)
-    cth = np.cos(alpha)
-    sphi = np.sin(az)
-    cphi = np.cos(az)
-    dir[:,0]=sth*cphi
-    dir[:,1]=sth*sphi
-    dir[:,2]=cth
-
-    cth = mt_array[:,0]*dir[:,2]*dir[:,2] +\
-          mt_array[:,1]*dir[:,0]*dir[:,0] +\
-          mt_array[:,2]*dir[:,1]*dir[:,1] +\
-       2*(mt_array[:,3]*dir[:,0]*dir[:,2] -\
-          mt_array[:,4]*dir[:,1]*dir[:,2] -\
-          mt_array[:,5]*dir[:,0]*dir[:,1])
-
-    cth[cth>0] = 1
-    cth[cth<0] = -1
-    return cth
-

--- a/mtuq/misfit/polarity.py
+++ b/mtuq/misfit/polarity.py
@@ -49,7 +49,7 @@ class PolarityMisfit(object):
         values = np.zeros((len(sources), 1))
 
         # Extracting measured polarities,  as a numpy array
-        observed_polarities = extract_polarity(polarity_input)
+        observed_polarities = extract_polarity(polarity_input, self.polarity_keyword)
 
         takeoff_angles = extract_takeoff_angle(greens, taup_model=self.taup_model)
 

--- a/mtuq/misfit/polarity.py
+++ b/mtuq/misfit/polarity.py
@@ -91,6 +91,10 @@ class PolarityMisfit(object):
 
         """
 
+        # Check if the greens functions passed to polarity misfit are for Moment Tensor sources.
+        if not all(green.include_mt for green in greens):
+            raise NotImplementedError('Polarity misfit does not support Force sources at the moment.')
+
         # Preallocate list containing source vector for faster computation.
         source_vector_list = _to_array(sources)
         # Create the array to store polarity misfit values.

--- a/mtuq/process_data.py
+++ b/mtuq/process_data.py
@@ -11,7 +11,7 @@ from os.path import basename, exists
 from mtuq.util import AttribDict, warn
 from mtuq.util.cap import WeightParser, taper
 from mtuq.util.signal import cut, get_arrival, m_to_deg
- 
+
 
 class ProcessData(object):
     """ An attempt at a one-size-fits-all data processing class
@@ -23,9 +23,9 @@ class ProcessData(object):
 
     .. code::
 
-        function = ProcessData(**parameters) 
+        function = ProcessData(**parameters)
 
-    Second, an ObsPy stream is given as input to the data processing function 
+    Second, an ObsPy stream is given as input to the data processing function
     and a processed stream returned as output:
 
     .. code::
@@ -63,7 +63,7 @@ class ProcessData(object):
     ``pick_type`` (`str`)
 
     - ``'taup'``
-      calculates P, S arrival times from Tau-P model 
+      calculates P, S arrival times from Tau-P model
       (uses `obspy.taup.TauPyModel.get_arrival_times`)
 
     - ``'FK_metadata'``
@@ -335,7 +335,7 @@ class ProcessData(object):
 
 
     def __call__(self, traces, station=None, origin=None, overwrite=False):
-        ''' 
+        '''
         Carries out data processing operations on obspy streams
         MTUQ GreensTensors
 
@@ -365,12 +365,16 @@ class ProcessData(object):
             station.latitude,
             station.longitude)
 
+        if not 'az' in station.sac:
+            print('adding azimuth in ', id)
+            station.sac['az'] = azimuth
+
         # collect time sampling information
         nt, dt = traces[0].stats.npts, traces[0].stats.delta
 
         # Tags can be added through dataset.add_tag to keep track of custom
         # metadata or support other customized uses. Here we use tags to
-        # distinguish data from Green's functions and displacement time series 
+        # distinguish data from Green's functions and displacement time series
         # from velcoity time series
         if not hasattr(traces, 'tags'):
             raise Exception('Missing tags attribute')
@@ -472,12 +476,12 @@ class ProcessData(object):
 
             if self.pick_type=='taup':
                 with warnings.catch_warnings():
-                    # supress obspy warning that gets raised even when taup is 
+                    # supress obspy warning that gets raised even when taup is
                     # used correctly (someone should submit an obspy fix)
                     warnings.filterwarnings('ignore')
                     arrivals = self._taup.get_travel_times(
-                        origin.depth_in_m/1000., 
-                        m_to_deg(distance_in_m), 
+                        origin.depth_in_m/1000.,
+                        m_to_deg(distance_in_m),
                         phase_list=['p', 's', 'P', 'S'])
                 try:
                     picks['P'] = get_arrival(arrivals, 'p')
@@ -536,11 +540,11 @@ class ProcessData(object):
 
             #
             # part 4b: apply statics
-            # 
+            #
 
             # STATIC CONVENTION:  A positive static time shift means synthetics
-            # are arriving too early and need to be shifted in the positive 
-            # direction to match the observed data. 
+            # are arriving too early and need to be shifted in the positive
+            # direction to match the observed data.
 
             if self.apply_statics:
                 try:
@@ -554,7 +558,7 @@ class ProcessData(object):
 
                 except:
                     # This way of getting the component from the channel is
-                    # actually what is hardwired into ObsPy, and is implemented 
+                    # actually what is hardwired into ObsPy, and is implemented
                     # here as a fallback
                     component = trace.stats.channel[-1].upper()
 
@@ -573,7 +577,7 @@ class ProcessData(object):
 
             #
             # part 4c: apply padding
-            # 
+            #
 
             # using a longer window for Green's functions than for data allows for
             # more accurate time-shift corrections
@@ -598,4 +602,3 @@ class ProcessData(object):
 
 
         return traces
-

--- a/mtuq/util/cap.py
+++ b/mtuq/util/cap.py
@@ -83,23 +83,27 @@ class WeightParser(object):
 
             for row in reader:
                 _code = self._parse_code(row[0])
-                _polarity = int(self._parse_polarity(row[0]))
-                print(_code, _polarity)
-
                 picks[_code]['P'] = float(row[7])
                 picks[_code]['S'] = float(row[9])
 
         return picks
 
-    def parse_polarity(self):
-
+    def parse_polarity(self, remove_unused=True):
+        polarities = []
         with open(self._path) as file:
             reader = csv.reader(
                 filter(lambda row: row[0]!='#', file),
                 delimiter=' ',
                 skipinitialspace=True)
 
-            polarities = [int(self._parse_polarity(row[0])) for row in reader]
+            for row in reader:
+                if not float(row[2]) ==\
+                float(row[3]) ==\
+                float(row[4]) ==\
+                float(row[5]) ==\
+                float(row[6]) == 0:
+                    polarities+=[int(self._parse_polarity(row[0]))]
+
         return polarities
 
 

--- a/mtuq/util/math.py
+++ b/mtuq/util/math.py
@@ -328,3 +328,33 @@ def lat_lon_tuples(center_lat=None,center_lon=None,
     return zip(lat, lon)
 
 
+def radiation_coef(mt_array, takeoff_angle, azimuth):
+    """ Computes P-wave radiation coefficient from a collection of sources (2D np.array with source parameter vectors), and the associated takeoff_angle and azimuth for a given station. The radiation coefficient is computed in mtuq orientation conventions.
+
+    Based on Aki & Richards, Second edition (2009), eq. 4.88, p. 108
+    """
+    # Check if mt_array is a 2D array, and make it 2D if not.
+    if len(mt_array.shape) == 1:
+        mt_array = np.array([mt_array])
+
+    alpha = np.deg2rad(takeoff_angle)
+    az = np.deg2rad(azimuth)
+    dir = np.zeros((len(mt_array), 3))
+    sth = np.sin(alpha)
+    cth = np.cos(alpha)
+    sphi = np.sin(az)
+    cphi = np.cos(az)
+    dir[:, 0] = sth*cphi
+    dir[:, 1] = sth*sphi
+    dir[:, 2] = cth
+
+    cth = mt_array[:, 0]*dir[:, 2]*dir[:, 2] +\
+        mt_array[:, 1]*dir[:, 0]*dir[:, 0] +\
+        mt_array[:, 2]*dir[:, 1]*dir[:, 1] +\
+        2*(mt_array[:, 3]*dir[:, 0]*dir[:, 2] -
+           mt_array[:, 4]*dir[:, 1]*dir[:, 2] -
+           mt_array[:, 5]*dir[:, 0]*dir[:, 1])
+
+    cth[cth > 0] = 1
+    cth[cth < 0] = -1
+    return cth

--- a/mtuq/util/polarity.py
+++ b/mtuq/util/polarity.py
@@ -8,24 +8,30 @@ from mtuq.util.cap import WeightParser
 def extract_polarity(polarity_in, polarity_keyword=None):
     """
     Extract first motion polarity from polarity_in input.
-    The function automatically detects the type of input to return an array of len(data) [-1, 0 , +1] integer values used in polarity mismatch misfit.
+    The function automatically detects the type of input to return an array of
+    len(data) containing [-1, 0 , +1] integer values used in polarity mismatch
+    misfit.
 
     .. rubric :: Required argument
     ``polarity_in`` (`list`, `numpy.ndarray`, `mtuq.dataset.Dataset`,
     `mtuq.greens_tensor.base.GreensTensorList, `str`):
 
-    When parsing `list` or `numpy.ndarray`, the number of entry should match the number of entries in the green's tensor list.
+    When parsing `list` or `numpy.ndarray`, the number of entry should match
+    the number of entries in the green's tensor list.
+
+    .. note::
+    In the case of mtuq.Dataset or mtuq.GreensTensorList, the picked polarity
+    info should be written in the header of the first trace of the stream for
+    each station.
 
     """
     if isinstance(polarity_in, (mtuq.dataset.Dataset)) and polarity_keyword is not None:
         observed_polarities = np.asarray([sta[0].stats.sac[polarity_keyword] for sta in polarity_in])
 
     elif isinstance(polarity_in, (mtuq.greens_tensor.base.GreensTensorList)) and polarity_keyword is not None:
-        print('detected as GreensTensorList')
         observed_polarities = np.asarray([sta[0].stats.sac[polarity_keyword] for sta in polarity_in])
 
     elif type(polarity_in) == list or type(polarity_in) == np.ndarray:
-        print('detected as list or numpy array')
         observed_polarities = polarity_in
 
     elif type(polarity_in) == str and polarity_in[-4:] == ".dat":
@@ -33,11 +39,17 @@ def extract_polarity(polarity_in, polarity_keyword=None):
 
     else:
         raise TypeError('No polarity information was found in the polarity_input passed. Check that your polarity input is either a mtuq Dataset, a mtuq GreensTensorList, a list or numpy array or the path to the CAP weight file.')
+
+    if not all(p == 0 or p == 1 or p==-1 for p in observed_polarities):
+        raise ValueError("At least one value in polarity_input is not a 1, 0 or -1.")
+
+
     return observed_polarities
 
 def calculate_takeoff_angle(taup, source_depth_in_km, **kwargs):
     """
-    Compute P arrival source-receiver takeoff angle, from the source-receiver geometry and a valid 1D obspy velocity model (expected in *.npz format).
+    Compute P arrival source-receiver takeoff angle, from the source-receiver
+    geometry and a valid 1D obspy velocity model (expected in *.npz format).
     """
 
     try:
@@ -53,7 +65,7 @@ def calculate_takeoff_angle(taup, source_depth_in_km, **kwargs):
         elif 'P' in phases:
             return arrivals[phases.index('P')].takeoff_angle
         else:
-            raise Excpetion
+            raise Exception
 
     except:
         # if taup fails, use dummy takeoff angle
@@ -61,7 +73,14 @@ def calculate_takeoff_angle(taup, source_depth_in_km, **kwargs):
 
 def extract_takeoff_angle(greens, taup_model='ak135'):
     """
-    Extract takeoff angle from Green's function input
+    Extract takeoff angle from Green's function input (FK Green's function
+    database), or compute it on the fly (Axisem database) using obspy.taup
+    velocity model.
+
+    .. note :
+    This function is a wrapper that determine the type of input, and then calls
+    mtuq.util.polarity.calculate_takeoff_angle when required (taup mode).
+
     """
     #Determine Green's function origin:
     solver = _get_tag(greens[0].tags, 'solver')

--- a/mtuq/util/polarity.py
+++ b/mtuq/util/polarity.py
@@ -5,7 +5,7 @@ from obspy.taup import TauPyModel
 from obspy.geodetics import kilometers2degrees as _to_deg
 from mtuq.util.cap import WeightParser
 
-def extract_polarity(polarity_in):
+def extract_polarity(polarity_in, polarity_keyword=None):
     """
     Extract first motion polarity from polarity_in input.
     The function automatically detects the type of input to return an array of len(data) [-1, 0 , +1] integer values used in polarity mismatch misfit.
@@ -18,11 +18,11 @@ def extract_polarity(polarity_in):
 
     """
     if isinstance(polarity_in, (mtuq.dataset.Dataset)) and polarity_keyword is not None:
-        observed_polarities = np.asarray([sta[0].stats.sac[polarity_keyword] for sta in data])
+        observed_polarities = np.asarray([sta[0].stats.sac[polarity_keyword] for sta in polarity_in])
 
     elif isinstance(polarity_in, (mtuq.greens_tensor.base.GreensTensorList)) and polarity_keyword is not None:
         print('detected as GreensTensorList')
-        observed_polarities = np.asarray([sta[0].stats.sac[polarity_keyword] for sta in data])
+        observed_polarities = np.asarray([sta[0].stats.sac[polarity_keyword] for sta in polarity_in])
 
     elif type(polarity_in) == list or type(polarity_in) == np.ndarray:
         print('detected as list or numpy array')

--- a/mtuq/util/polarity.py
+++ b/mtuq/util/polarity.py
@@ -86,8 +86,10 @@ def extract_takeoff_angle(greens, taup_model='ak135'):
     solver = _get_tag(greens[0].tags, 'solver')
     if solver == 'FK':
         mode = 'FK'
-    else:
+    elif solver == 'AxiSEM' or solver == 'syngine':
         mode = 'taup'
+    else:
+        raise NotImplementedError('Greens function currently supported include AxiSEM, syngine and FK.')
 
     # List takeoff_angle and azimuth out of the provided data
     if mode == 'FK':

--- a/mtuq/util/polarity.py
+++ b/mtuq/util/polarity.py
@@ -1,0 +1,93 @@
+
+import mtuq
+import numpy as np
+from obspy.taup import TauPyModel
+from obspy.geodetics import kilometers2degrees as _to_deg
+from mtuq.util.cap import WeightParser
+
+def extract_polarity(polarity_in):
+    """
+    Extract first motion polarity from polarity_in input.
+    The function automatically detects the type of input to return an array of len(data) [-1, 0 , +1] integer values used in polarity mismatch misfit.
+
+    .. rubric :: Required argument
+    ``polarity_in`` (`list`, `numpy.ndarray`, `mtuq.dataset.Dataset`,
+    `mtuq.greens_tensor.base.GreensTensorList, `str`):
+
+    When parsing `list` or `numpy.ndarray`, the number of entry should match the number of entries in the green's tensor list.
+
+    """
+    if isinstance(polarity_in, (mtuq.dataset.Dataset)) and polarity_keyword is not None:
+        observed_polarities = np.asarray([sta[0].stats.sac[polarity_keyword] for sta in data])
+
+    elif isinstance(polarity_in, (mtuq.greens_tensor.base.GreensTensorList)) and polarity_keyword is not None:
+        print('detected as GreensTensorList')
+        observed_polarities = np.asarray([sta[0].stats.sac[polarity_keyword] for sta in data])
+
+    elif type(polarity_in) == list or type(polarity_in) == np.ndarray:
+        print('detected as list or numpy array')
+        observed_polarities = polarity_in
+
+    elif type(polarity_in) == str and polarity_in[-4:] == ".dat":
+        observed_polarities = WeightParser(polarity_in).parse_polarity()
+
+    else:
+        raise TypeError('No polarity information was found in the polarity_input passed. Check that your polarity input is either a mtuq Dataset, a mtuq GreensTensorList, a list or numpy array or the path to the CAP weight file.')
+    return observed_polarities
+
+def calculate_takeoff_angle(taup, source_depth_in_km, **kwargs):
+    """
+    Compute P arrival source-receiver takeoff angle, from the source-receiver geometry and a valid 1D obspy velocity model (expected in *.npz format).
+    """
+
+    try:
+        arrivals = taup.get_travel_times(source_depth_in_km, **kwargs)
+
+        phases = []
+        for arrival in arrivals:
+            phases += [arrival.phase.name]
+
+        if 'p' in phases:
+            return arrivals[phases.index('p')].takeoff_angle
+
+        elif 'P' in phases:
+            return arrivals[phases.index('P')].takeoff_angle
+        else:
+            raise Excpetion
+
+    except:
+        # if taup fails, use dummy takeoff angle
+        return None
+
+def extract_takeoff_angle(greens, taup_model='ak135'):
+    """
+    Extract takeoff angle from Green's function input
+    """
+    #Determine Green's function origin:
+    solver = _get_tag(greens[0].tags, 'solver')
+    if solver == 'FK':
+        mode = 'FK'
+    else:
+        mode = 'taup'
+
+    # List takeoff_angle and azimuth out of the provided data
+    if mode == 'FK':
+        takeoff_angles = [sta[-1].stats.sac['user1'] for sta in greens]
+    elif mode == 'taup':
+        model = TauPyModel(taup_model)
+        takeoff_angles = [calculate_takeoff_angle(model,
+        sta.station.sac['evdp'],
+        distance_in_degree = _to_deg(sta.station.sac['dist']),
+        phase_list=['p', 'P']) for sta in greens]
+        # except:
+        #     raise TypeError('Something went wrong with retriving takeoff_angles')
+    return takeoff_angles
+
+
+def _get_tag(tags, pattern):
+    for tag in tags:
+        parts = tag.split(':')
+        if parts[0]==pattern:
+            return parts[1]
+    else:
+        return None


### PR DESCRIPTION
The polarity misfit implementation has been entirely reworked to allow more flexibility in terms of inputs.

The polarity misfit now accepts a greater range of input types, from lists and NumPy arrays of [1,0,-1] values, CAP weight file path (legacy mode, compatible with CAPUAF input styles), and mtuq.Dataset or mtuq.GreensTensorList with a correctly set SAC header. 
This update also grants flexibility in terms of header keyword choice, as it allows defining a custom keyword as input when initializing the polarity misfit object.

This new implementation also lets users specify a valid obspy.taup TauPyModel object to compute the takeoff angle in a 1D model on the fly, or will automatically read the takeoff angle written by FK in the green's function SAC header (in 'user1' field). If not provided, it will default to ak135.

The beachball_pygmt plot function has been updated accordingly, to reflect these changes and adopt the same automatic input management style.
The function relatives to on-the-fly computation of takeoff angle or observed polarity parsing, have been moved to a dedicated polarity script in the util folder.

An example has been added in the mtuq example folder.