### PR TITLE
Update syngine.py

### DIFF
--- a/mtuq/util/syngine.py
+++ b/mtuq/util/syngine.py
@@ -72,7 +72,7 @@ def download_unzip_mt_response(url, model, station, origin, verbose=True):
          +'&starttime='+str(origin.time)[:-1])
 
     try:
-       dirname = os.environs['SYNGINE_CACHE']
+       dirname = os.environ['SYNGINE_CACHE']
     except:
        dirname = 'data/greens_tensor/syngine/cache/'
 


### PR DESCRIPTION
Corrected environment variable check, as 'os' has no attribute 'environs'. This will be needed in order to use mtuq and syngine on Frontera, as syngine green's tensor can currently only be written on the /home/ directory of the container. 

Correcting this typo should allow users to define the SYNGINE_CACHE environment variable such that the Green's tensors can be written outside of the container (on the $SCRATCH directory for instance).