### PR TITLE
Axisem Radial component force fix

### DIFF
--- a/mtuq/greens_tensor/AxiSEM.py
+++ b/mtuq/greens_tensor/AxiSEM.py
@@ -19,7 +19,7 @@ class GreensTensor(GreensTensorBase):
       symmetric medium.  Time series represent vertical, radial, and transverse
       displacement in units of m*(N-m)^-1
 
-      For the vertical and raidal components, there are four associated time 
+      For the vertical and raidal components, there are four associated time
       series. For the tranverse component, there are two associated time
       series. Thus there are ten independent Green's tensor elements altogether,
       which is fewer than in the case of a general inhomogeneous medium
@@ -115,9 +115,11 @@ class GreensTensor(GreensTensorBase):
                 array[_i, _j+2, :] = Z2
 
             elif component=='R':
-                R0 = self.select(channel="R0")[0].data
-                R1 = self.select(channel="R1")[0].data
-                R2 = self.select(channel="R2")[0].data
+                # Manual fix of the Radial component polarity
+                # until Axisem/Syngine Force get fixed.
+                R0 = self.select(channel="R0")[0].data * -1
+                R1 = self.select(channel="R1")[0].data * -1
+                R2 = self.select(channel="R2")[0].data * -1
                 array[_i, _j+0, :] = R0
                 array[_i, _j+1, :] = R1
                 array[_i, _j+2, :] = R2
@@ -138,7 +140,7 @@ class GreensTensor(GreensTensorBase):
         # The mathematical formulas above are based on the North-East-Down
         # convention, but mtuq works in the Up-South-East convention.
         # We could get equivalent results by permuting the get_synthetics
-        # arguments every time it is called, but it is faster to permute the 
+        # arguments every time it is called, but it is faster to permute the
         # whole array once and for all
 
         array = self._array
@@ -150,4 +152,3 @@ class GreensTensor(GreensTensorBase):
         array[:, 3, :] =  array_copy[:, 4, :]
         array[:, 4, :] = -array_copy[:, 5, :]
         array[:, 5, :] = -array_copy[:, 3, :]
-

--- a/mtuq/util/math.py
+++ b/mtuq/util/math.py
@@ -208,8 +208,17 @@ def to_xyz(F0, phi, h):
 
 def to_rtp(F0, phi, h):
     """ Converts from spherical to Cartesian coordinates (up-south-east)
+
+    Parameters:
+    F0 (float or numpy array): The radial distance from the origin
+    phi (float or numpy array): The azimuthal angle in degrees - 0 to 360 range, where 0 is East. Anticlockwise positive.
+    h (float or numpy array): The cosine of the polar angle - -1 to 1 range, where 1 is Up
+    
+    Returns:
+    numpy array: The Cartesian coordinates in the up-south-east system
     """
     # spherical coordinates in "physics convention"
+    
     r = F0
     phi = np.radians(phi)
     theta = np.arccos(h)

--- a/tests/test_force_polarity.py
+++ b/tests/test_force_polarity.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import unittest
+import numpy as np
+import requests
+import zipfile
+from obspy import read
+import os
+
+class TestSyngineForcePolarity(unittest.TestCase):
+    """ Test that the force response is correct. MTUQ currently contains 
+    a fix for the polarity error in the Radial coordinate. If this test
+    fails, the fix may need to be updated. It currently expects the
+    polarity of E and R to be opposite.
+    
+    This test is based on the URL Builder: syngine v.1 
+    http://service.iris.washington.edu/irisws/syngine/docs/1/builder/
+    """
+
+    def test_force_response(self):
+        url = "http://service.iris.washington.edu/irisws/syngine/1/query?model=ak135f_5s&format=saczip&components=ZRE&units=displacement&receiverlatitude=0&receiverlongitude=1&sourcelatitude=0&sourcelongitude=0&sourcedepthinmeters=0&sourceforce=1e12,0,0&nodata=404"
+
+        response = requests.get(url)
+
+        if response.status_code == 200:
+            with open("data.zip", "wb") as f:
+                f.write(response.content)
+
+            with zipfile.ZipFile("data.zip", "r") as zip_ref:
+                zip_ref.extractall(".")
+
+        components = 'ZRE'
+        # The format of sac files is the following XX.S0001.SE.MX[component].sac
+        # where XX is the network code, S0001 is the station code, SE is the
+        # location code, MX is the channel code, and [component] is the
+        # component code. The component code is one of Z, R, E
+
+        # Read the sac files
+        st = read('*.sac')
+
+        # Get the data for E and R
+        for tr in st:
+            if tr.stats.channel == 'MXE':
+                E = tr.data
+            if tr.stats.channel == 'MXR':
+                R = tr.data
+
+        # The polarity of E and R should be opposit. 
+        # Display a custom error message if this is not the case.
+        self.assertTrue(np.allclose(E, R), msg='The polarity of E and R is not opposite. The fix for the polarity error in the Radial coordinate may need to be updated.')
+
+        # Remove all sac files, the Syngine.log and the data.zip
+        os.remove('data.zip')
+        os.remove('Syngine.log')
+        for tr in st:
+            os.remove(tr.stats.network+'.'+tr.stats.station+'.'+tr.stats.location+'.'+tr.stats.channel+'.sac')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Here is the fix discussed in #193.

The simple fix is simply to modify the green's function Radial comp by flipping the sign. 

I also have created a functional test that tests if the Radial from Syngine is sign-flipped, in order for us to catch any fix that might happen on their side in the future.

My main concern is that an Instaseis fix could still run silently for someone who does not run tests frequently (or who runs them only once at install and never touches the repo again). I would love to have suggestions to address this issue.

If someone can also double-check the Docstrings that I have added in the to_rtp() function in [d3e79aa](https://github.com/uafgeotools/mtuq/pull/195/commits/d3e79aab3228466505b7158f3508d7631c7ee4ba), that would also be helpful. 