### PR TITLE
Minimal solution to fix weight implementation in level2 misfit.

### DIFF
--- a/mtuq/misfit/waveform/level2.py
+++ b/mtuq/misfit/waveform/level2.py
@@ -63,7 +63,7 @@ def misfit(data, greens, sources, norm, time_shift_groups,
     # collect message attributes
     #
     try:
-        msg_args = [getattr(msg_handle, attrib) for attrib in 
+        msg_args = [getattr(msg_handle, attrib) for attrib in
             ['start', 'stop', 'percent']]
     except:
         msg_args = [0, 0, 0]
@@ -185,7 +185,7 @@ def _get_mask(data, stations, components):
 
     mask = np.ones((
         Nstations,
-        Ncomponents, 
+        Ncomponents,
         ))
 
     for _i, station in enumerate(stations):
@@ -196,7 +196,9 @@ def _get_mask(data, stations, components):
 
             if len(stream)==0:
                 mask[_i, _j] = 0.
-
+            else :
+                mask[_i, _j] = stream[0].attrs.weight
+                
     return mask
 
 
@@ -214,8 +216,8 @@ def _get_groups(groups, components):
     Ngroups = len(groups)
 
     array = np.zeros((
-        Ngroups, 
-        Ncomponents, 
+        Ngroups,
+        Ncomponents,
         ))
 
     for _i, group in enumerate(groups):
@@ -343,14 +345,14 @@ def _autocorr_2(greens, padding):
     Ngreens = greens.shape[2]
     Npts = greens.shape[3]
 
-    ones = np.pad(np.ones(Npts), 
+    ones = np.pad(np.ones(Npts),
         (padding[0], padding[1]), 'constant')
 
     corr = np.zeros((
         Nstations,
-        Ncomponents, 
-        padding[0]+padding[1]+1, 
-        Ngreens, 
+        Ncomponents,
+        padding[0]+padding[1]+1,
+        Ngreens,
         Ngreens,
         ))
 
@@ -368,5 +370,3 @@ def _autocorr_2(greens, padding):
                         corr[_i, _j, :, _k1, _k2] = corr[_i, _j, :, _k2, _k1]
 
     return corr
-
-


### PR DESCRIPTION
Patch for Issue #185 . 

Allow to take non {0,1} weights in weight file.