### PR TITLE
Changed the skip trace condition to allow non (int) weights.

### DIFF
--- a/mtuq/misfit/waveform/c_ext_L2.c
+++ b/mtuq/misfit/waveform/c_ext_L2.c
@@ -145,6 +145,19 @@ static PyObject *misfit(PyObject *self, PyObject *args) {
   }
 
   //
+  // Print the weights for each component of each station, with numbering to keep track of things
+  //
+
+  if (debug_level>1) {
+    printf("The weights: \n");
+    for (ista=0; ista<NSTA; ista++) {
+      for (ic=0; ic<NC; ic++) {
+        printf("  %d %d %f \n", ista, ic, weights(ista, ic));
+      }
+    }
+  }
+
+  //
   // Iterate over sources
   //
 
@@ -168,7 +181,7 @@ static PyObject *misfit(PyObject *self, PyObject *args) {
         /*
 
         Finds the shift between data and synthetics that yields the maximum
-        cross-correlation value across all components in the given component 
+        cross-correlation value across all components in the given component
         group, subject to the (time_shift_min, time_shift_max) constraint
 
         */
@@ -185,7 +198,7 @@ static PyObject *misfit(PyObject *self, PyObject *args) {
            }
 
           // Skip traces that have been assigned zero weight
-          if (((int) weights(ista,ic))==0) {
+          if (fabs(weights(ista, ic)) < 1e-6) {
               if (debug_level>1) {
                 if (isrc==0) {
                   printf(" skipping trace: %d %d\n", ista, ic);
@@ -229,10 +242,10 @@ static PyObject *misfit(PyObject *self, PyObject *args) {
           // Skip components not in the component group being considered
           if (((int) groups(igrp,ic))==0) {
             continue;
-          } 
+          }
 
           // Skip traces that have been assigned zero weight
-          if (((int) weights(ista,ic))==0) {
+          if (fabs(weights(ista, ic)) < 1e-6) {
               continue;
           }
 
@@ -249,11 +262,17 @@ static PyObject *misfit(PyObject *self, PyObject *args) {
 
           // calculate sd
           for (ig=0; ig<NG; ig++) {
-            L2_tmp -= 2.*greens_data(ista,ic,ig,itpad) * sources(isrc, ig); 
+            L2_tmp -= 2.*greens_data(ista,ic,ig,itpad) * sources(isrc, ig);
           }
 
           if (hybrid_norm==0) {
               // L2 norm
+              // Print the weight value
+              if (debug_level>1) {
+                if (isrc==0) {
+                  printf(" weight: %d %d %f \n", ista, ic, weights(ista, ic));
+                }
+              }
               L2_sum += dt * weights(ista,ic) * L2_tmp;
           }
           else {
@@ -273,7 +292,7 @@ static PyObject *misfit(PyObject *self, PyObject *args) {
 
 
 //
-// Boilerplate 
+// Boilerplate
 //
 
 static PyMethodDef methods[] = {

--- a/mtuq/misfit/waveform/c_ext_L2.c
+++ b/mtuq/misfit/waveform/c_ext_L2.c
@@ -198,7 +198,7 @@ static PyObject *misfit(PyObject *self, PyObject *args) {
            }
 
           // Skip traces that have been assigned zero weight
-          if (fabs(weights(ista, ic)) < 1e-6) {
+          if (fabs(weights(ista, ic)) < 1.e-6) {
               if (debug_level>1) {
                 if (isrc==0) {
                   printf(" skipping trace: %d %d\n", ista, ic);
@@ -245,7 +245,7 @@ static PyObject *misfit(PyObject *self, PyObject *args) {
           }
 
           // Skip traces that have been assigned zero weight
-          if (fabs(weights(ista, ic)) < 1e-6) {
+          if (fabs(weights(ista, ic)) < 1.e-6) {
               continue;
           }
 


### PR DESCRIPTION
I found out that my previous solution to account for the weights in the level2/C implementation of the misfit measure had a flaw, and would not let users input non-integer weights.

The previous condition for skip was:
```c
          // Skip traces that have been assigned zero weight
          if (((int) weights(ista,ic))==0) {
```
which I didn't realize when I fixed #185. This condition prevents to use of any non-integer weights, as they will be rounded to an integer.

I propose this instead:
```c
          // Skip traces that have been assigned zero weight
          if (fabs(weights(ista, ic)) < 1e-6) {
```
which will check if the absolute value of the weights is smaller than 1e-6 (should be a reasonable threshold and will avoid any bad surprises even in the case of someone using ridiculously small weights).

But this might be me being a bit too precautious. Another simple option would be:
```c
          // Skip traces that have been assigned zero weight
          if (weights(ista, ic) == 0.0) {
``` 

I also added a few debugging options to print the weights passed to c_ext_l2.c, just for good measure.