### PR TITLE
3D SPECFEM GF implementation

### DIFF
--- a/mtuq/greens_tensor/SPECFEM3D.py
+++ b/mtuq/greens_tensor/SPECFEM3D.py
@@ -77,6 +77,28 @@ class GreensTensor(GreensTensorBase):
 
 
     def _precompute_force(self):
-        raise NotImplementedError
+        #raise NotImplementedError
+        """ Assembles NumPy arrays used in force linear combination
+        """
+
+        array = self._array
+        phi = np.deg2rad(self.azimuth)
+        _j = 0
+
+        for _i, component in enumerate(self.components):
+            if component=='Z':
+                array[_i, _j+0, :] = self.select(channel="Z.Fe")[0].data
+                array[_i, _j+1, :] = self.select(channel="Z.Fn")[0].data
+                array[_i, _j+2, :] = self.select(channel="Z.Fz")[0].data
+
+            elif component=='R':
+                array[_i, _j+0, :] = self.select(channel="R.Fe")[0].data
+                array[_i, _j+1, :] = self.select(channel="R.Fn")[0].data
+                array[_i, _j+2, :] = self.select(channel="R.Fz")[0].data
+
+            elif component=='T':
+                array[_i, _j+0, :] = self.select(channel="T.Fe")[0].data
+                array[_i, _j+1, :] = self.select(channel="T.Fn")[0].data
+                array[_i, _j+2, :] = self.select(channel="T.Fz")[0].data
 
 

--- a/mtuq/io/clients/SPECFEM3D_SAC.py
+++ b/mtuq/io/clients/SPECFEM3D_SAC.py
@@ -112,7 +112,14 @@ class Client(ClientBase):
                 stream += trace
 
         if self.include_force:
-            raise NotImplementedError
+            #raise NotImplementedError
+            SUFFIXES = ['R.Fe','T.Fe','Z.Fe','R.Fn','T.Fn','Z.Fn','R.Fz','T.Fz','Z.Fz']
+            for suffix in SUFFIXES:
+                trace = obspy.read(
+                    self.path+'/'+prefix+'.'+suffix+'.sac', format='sac')[0]
+                trace.stats.channel = suffix
+                trace.stats._component = suffix[0]
+                stream += trace
 
 
         # what are the start and end times of the data?

--- a/mtuq/io/clients/SPECFEM3D_SAC.py
+++ b/mtuq/io/clients/SPECFEM3D_SAC.py
@@ -9,7 +9,7 @@ from mtuq.io.clients.base import Client as ClientBase
 from mtuq.util.signal import resample
 
 
-SUFFIXES = [
+EXT_MT= [
     'Z.Mrr',
     'Z.Mtt',
     'Z.Mpp',
@@ -29,6 +29,19 @@ SUFFIXES = [
     'T.Mrp',
     'T.Mtp',
     ]
+
+EXT_FORCE = [
+    'R.Fe',
+    'T.Fe',
+    'Z.Fe',
+    'R.Fn',
+    'T.Fn',
+    'Z.Fn',
+    'R.Fz',
+    'T.Fz',
+    'Z.Fz',
+    ]
+
 
 
 class Client(ClientBase):
@@ -104,7 +117,7 @@ class Client(ClientBase):
             prefix = _try_wildcards(self.path, station)
             
         if self.include_mt:
-            for suffix in SUFFIXES:
+            for suffix in EXT_MT:
                 trace = obspy.read(
                     self.path+'/'+prefix+'.'+suffix+'.sac', format='sac')[0]
                 trace.stats.channel = suffix
@@ -112,9 +125,7 @@ class Client(ClientBase):
                 stream += trace
 
         if self.include_force:
-            #raise NotImplementedError
-            SUFFIXES = ['R.Fe','T.Fe','Z.Fe','R.Fn','T.Fn','Z.Fn','R.Fz','T.Fz','Z.Fz']
-            for suffix in SUFFIXES:
+            for suffix in EXT_FORCE:
                 trace = obspy.read(
                     self.path+'/'+prefix+'.'+suffix+'.sac', format='sac')[0]
                 trace.stats.channel = suffix
@@ -177,4 +188,5 @@ def _try_wildcards(path, station):
             return wildcard
     else:
         raise FileNotFoundError()
+
 


### PR DESCRIPTION
As discussed in [Issue 203](https://github.com/uafgeotools/mtuq/issues/203), I have implemented using 3D Green's Functions for force generated in SPECFEM3D. There are no major changes to existing code, and the implementation was similar to that of the 3D Green's Functions for moment tensors generated in SPECFEM3D. 

The filename convention for the GFs reflects that for the FORCESOLUTION file in SPECFEM3D, you give the east, north, and vertical components of force.