### PR TITLE
Modified attribute utility function in annotations

### DIFF
--- a/mtuq/graphics/annotations.py
+++ b/mtuq/graphics/annotations.py
@@ -79,14 +79,11 @@ def trace_label_writer(axis, dat, syn, total_misfit=1.):
 #
 
 def _getattr(trace, name, *args):
-    if len(args)==1:
-        if not hasattr(trace, 'attrs'):
-            return args[0]
-        else:
-            return getattr(trace.attrs, name, args[0])
-    elif len(args)==0:
+    # Check if trace has an 'attrs' attribute and if name is an attribute of trace.attrs
+    if hasattr(trace, 'attrs') and hasattr(trace.attrs, name):
         return getattr(trace.attrs, name)
-    else:
-        raise TypeError("Wrong number of arguments")
+    
+    # If not, check directly on trace's attributes
+    return getattr(trace, name, args[0] if args else None)
 
 


### PR DESCRIPTION
The utility function that reads attributes to be plotted as annotations by the waveform plot has been modified to check if 
`trace.attrs.static_time_shift`
or
`trace.static_time_shift`
exist. 

`trace.static_time_shift` is set as trace attribute by ProcessData() during the pre-processing stage, and it was not correctly checked by the current function.
After this fix, the annotations correctly account for static correction being applied to the synthetics (tested on 2009 example case).

Alternative solution: Make ProcessData() allocate the `static_time_shift` directly in `trace.attrs`, if we want to keep all plotting attributes grouped within a single group. This might not be completely straightforward depending on the list of all attributes that are allocated in `attrs` by the code (do we need several attributes groups?).