### PR TITLE
Implementation of median amplitude normalization.

### DIFF
--- a/data/examples/unpack.bash
+++ b/data/examples/unpack.bash
@@ -9,7 +9,7 @@ cd $(dirname ${BASH_SOURCE[0]})
 wd=$PWD
 
 for filename in \
-    20090407201255351.tgz 20210809074550.tgz 20SPECFEM3D_SGT.tgz SPECFEM3D_SAC.tgz;
+    20090407201255351.tgz 20210809074550.tgz SPECFEM3D_SGT.tgz SPECFEM3D_SAC.tgz;
 do
     cd $wd
     cd $(dirname $filename)

--- a/mtuq/graphics/annotations.py
+++ b/mtuq/graphics/annotations.py
@@ -3,6 +3,8 @@ import numpy as np
 
 from matplotlib import pyplot
 from obspy.geodetics import gps2dist_azimuth
+# location to degree distance with obspy
+from obspy.geodetics import locations2degrees
 
 
 def station_label_writer(ax, station, origin, units='km'):
@@ -31,7 +33,8 @@ def station_label_writer(ax, station, origin, units='km'):
         label = '%d km' % round(distance_in_m/1000.)
 
     elif units=='deg':
-        label = '%d%s' % (round(m_to_deg(distance_in_m)), u'\N{DEGREE SIGN}')
+        label = '%d%s' % (round(locations2degrees(origin.latitude, origin.longitude,
+            station.latitude, station.longitude)), u'\N{DEGREE SIGN}')
 
     pyplot.text(0.2,0.35, label, fontsize=11, transform=ax.transAxes)
 
@@ -88,5 +91,4 @@ def _getattr(trace, name, *args):
         return getattr(trace.attrs, name)
     else:
         raise TypeError("Wrong number of arguments")
-
 

--- a/mtuq/graphics/header.py
+++ b/mtuq/graphics/header.py
@@ -114,7 +114,7 @@ class SourceHeader(Base):
         if not self.process_bw:
             pass
         if not self.process_sw:
-            raise Excpetion()
+            raise Exception()
 
         if self.process_sw.freq_max > 1.:
             units = 'Hz'

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     # (consider using a conda based installation instead)
     install_requires=[
         "numpy", 
-        "scipy",
+        "scipy<1.13.0",
         "pandas",
         "xarray",
         "netCDF4",


### PR DESCRIPTION
See PR #252 for complete discussion.

> I've moved the normalization logic out of the plotting function in order to fix the stream-per-stream normalization, and allow the addition of median based normalization. I haven't changed the default (still based on the maximum value in the dataset). Having the median normalization should help visualize the dataset when big changes in amplitudes are expected (for strong-motion data for instance).

This also comes with minor fixes for the waveform plots.