### PR TITLE
Added station count in default header

### DIFF
--- a/mtuq/graphics/waveforms.py
+++ b/mtuq/graphics/waveforms.py
@@ -285,7 +285,7 @@ def plot_data_greens1(filename,
 
         header = _prepare_header(
             model, solver, source, source_dict, origin,
-            process_data, misfit, total_misfit)
+            process_data, misfit, total_misfit, data_sw=data)
 
     plot_waveforms1(filename,
         data, synthetics, stations, origin,
@@ -340,7 +340,8 @@ def plot_data_greens2(filename,
         header = _prepare_header(
             model, solver, source, source_dict, origin,
             process_data_bw, process_data_sw,
-            misfit_bw, misfit_sw, total_misfit_bw, total_misfit_sw)
+            misfit_bw, misfit_sw, total_misfit_bw, total_misfit_sw,
+            data_bw=data_bw, data_sw=data_sw)
 
     plot_waveforms2(filename,
         data_bw, data_sw, synthetics_bw, synthetics_sw, stations, origin,
@@ -636,7 +637,7 @@ def _hide_axes(axes):
             col.patch.set_visible(False)
 
 
-def _prepare_header(model, solver, source, source_dict, origin, *args):
+def _prepare_header(model, solver, source, source_dict, origin, *args, **kwargs):
     # prepares figure header
 
     if len(args)==3:
@@ -644,11 +645,11 @@ def _prepare_header(model, solver, source, source_dict, origin, *args):
 
     if type(source)==MomentTensor:
         return MomentTensorHeader(
-            *args, model, solver, source, source_dict, origin)
+            *args, model, solver, source, source_dict, origin, **kwargs)
 
     elif type(source)==Force:
         return ForceHeader(
-            *args, model, solver, source, source_dict, origin)
+            *args, model, solver, source, source_dict, origin, **kwargs)
 
     else:
         raise TypeError


### PR DESCRIPTION
Here is an attempt at the least invasive change for the header station count. It is based of the existing helper function structure in the `SourceHeader` class with the addition of `parse_station_counts`.

It implements a way to count the total number of station, in case the body and surface waves were to be loaded from different weight file instances (in principle it should be rare, but that's an extra layer of precaution).

The next (and only) foreseeable change to the header would be the inclusion of an `*` modifier added to fixed parameters. This should easily be done with the help of the `grid.shape` attributes, but we currently don't have a clean way of adding the grid (if we want to be the default behavior, we would have to change the input parameters for `plot_data_greens1` and `plot_data_greens2`).