### PR TITLE
define a new window_type, synthetic, for synthetic test.

### DIFF
--- a/mtuq/process_data.py
+++ b/mtuq/process_data.py
@@ -317,6 +317,11 @@ class ProcessData(object):
             self.window_length = window_length
             _window_warnings(window_type, window_length)
 
+        elif self.window_type == 'synthetic':
+            # window type for synthetic examples
+            assert window_length > 0.
+            self.window_length = window_length
+
         else:
             raise ValueError('Bad parameter: window_type')
 
@@ -701,6 +706,14 @@ class ProcessData(object):
                     starttime = average_time - self.window_length/2.
                     endtime = average_time + self.window_length/2.
 
+                starttime += float(origin.time)
+                endtime += float(origin.time)
+
+            elif self.window_type == 'synthetic':
+                # window type for synthetic examples
+                # waveform starts at 0.0
+                starttime = 0.0
+                endtime = starttime + self.window_length
                 starttime += float(origin.time)
                 endtime += float(origin.time)
 


### PR DESCRIPTION
We define a new 'window_type' named 'synthetic' for synthetic examples in our HMC package, seisHMC, since it relies on the functions in MTUQ. Here are the examples using synthetic waveforms: 
* GridSearch + DoubleCouple: https://github.com/Liang-Ding/seishmc/blob/main/examples/GridSearch.SYN.DoubleCouple.py 
* HMC + DoubleCouple: https://github.com/Liang-Ding/seishmc/blob/main/examples/HMC.SYN.DoubleCouple.py 
* GridSearch + FMT: https://github.com/Liang-Ding/seishmc/blob/main/examples/GridSearch.FullMomentTensor.py 
* HMC + FMT: https://github.com/Liang-Ding/seishmc/blob/main/examples/HMC.SYN.FullMomentTensor.py
We achieve lower waveform misfits in our examples using HMC algorithm. Check the figure: [misfit comparison](https://github.com/Liang-Ding/seishmc/blob/main/doc/images/misfit_comparison.jpg)

Additional results are avaliable at: https://github.com/Liang-Ding/seishmc/blob/main/doc/gallery.md. 
