### PR TITLE
Updates syngine client

### DIFF
--- a/mtuq/io/clients/syngine.py
+++ b/mtuq/io/clients/syngine.py
@@ -152,7 +152,9 @@ class Client(ClientBase):
 
 
 
-def download_greens_tensors(stations=[], origins=[], model='', verbose=False, **kwargs):
+def download_greens_tensors(stations=[], origins=[], model='', 
+                            cache_path=None, verbose=False, **kwargs):
+
     """ Downloads Green's tensors from syngine
 
     Downloads Green's functions for all combinations of stations and origins
@@ -177,4 +179,5 @@ def download_greens_tensors(stations=[], origins=[], model='', verbose=False, **
 
     """
     client = Client(model=model, **kwargs)
-    return client.get_greens_tensors(stations, origins, verbose=verbose)
+    return client.get_greens_tensors(
+        stations, origins, cache_path=cache_path, verbose=verbose)

--- a/mtuq/io/clients/syngine.py
+++ b/mtuq/io/clients/syngine.py
@@ -42,7 +42,8 @@ class Client(ClientBase):
     """
 
     def __init__(self, path_or_url=None, model=None,
-                 include_mt=True, include_force=False):
+                 include_mt=True, include_force=False,
+                 cache_path=None):
 
         if not path_or_url:
             path_or_url = 'http://service.iris.edu/irisws/syngine/1'
@@ -54,6 +55,8 @@ class Client(ClientBase):
 
         self.include_mt = include_mt
         self.include_force = include_force
+
+        self.cache_path = cache_path
 
 
     def get_greens_tensors(self, stations=[], origins=[], verbose=False):
@@ -82,7 +85,8 @@ class Client(ClientBase):
 
         if self.include_mt:
             dirname = download_unzip_mt_response(
-                self.url, self.model, station, origin)
+                self.url, self.model, station, origin, 
+                cache_path=self.cache_path)
 
             for filename in GREENS_TENSOR_FILENAMES:
                 stream += obspy.read(dirname+'/'+filename, format='sac')

--- a/mtuq/util/syngine.py
+++ b/mtuq/util/syngine.py
@@ -110,13 +110,13 @@ def download_unzip_mt_response(url, model, station, origin, verbose=True):
     return path
 
 
-def download_synthetics(url, model, station, origin, source):
+def download_synthetics(url, model, station, origin, source, cache_path=None):
     """ Downloads synthetics through syngine URL interface
     """
     if len(source)==6:
-        args='&sourcemomenttensor='+re.sub('\+','',",".join(map(str, source)))
+        args='&sourcemomenttensor='+re.sub(r'\+','',",".join(map(str, source)))
     elif len(source)==3:
-        args='&sourceforce='+re.sub('\+','',",".join(map(str, source)))
+        args='&sourceforce='+re.sub(r'\+','',",".join(map(str, source)))
     else:
         raise TypeError
 
@@ -133,9 +133,9 @@ def download_synthetics(url, model, station, origin, source):
          +'&starttime='+str(origin.time)[:-1])
 
     if len(source)==6:
-        url+='&sourcemomenttensor='+re.sub('\+','',",".join(map(str, source)))
+        url+='&sourcemomenttensor='+re.sub(r'\+','',",".join(map(str, source)))
     elif len(source)==3:
-        url+='&sourceforce='+re.sub('\+','',",".join(map(str, source)))
+        url+='&sourceforce='+re.sub(r'\+','',",".join(map(str, source)))
     else:
         raise TypeError
 

--- a/mtuq/util/syngine.py
+++ b/mtuq/util/syngine.py
@@ -65,7 +65,7 @@ def resolve_model(name):
         raise ValueError('Bad model')
 
 
-def download_unzip_mt_response(url, model, station, origin, verbose=True):
+def download_unzip_mt_response(url, model, station, origin, cache_path=None, verbose=True):
     """ Downloads Green's functions through syngine URL interface
     """
     url = (url+'/'+'query'
@@ -77,12 +77,8 @@ def download_unzip_mt_response(url, model, station, origin, verbose=True):
          +'&origintime='+str(origin.time)[:-1]
          +'&starttime='+str(origin.time)[:-1])
 
-    try:
-       dirname = os.environ['SYNGINE_CACHE']
-    except:
-       dirname = fullpath('data/greens_tensor/syngine/cache/')
-
-    path = abspath(join(dirname, str(url2uuid(url))))
+    # where the Green's functions will be cached locally
+    path = join(_check(cache_path), str(url2uuid(url)))
 
     if exists(path):
         # if unzipped directory already exists, return its absolute path
@@ -139,7 +135,9 @@ def download_synthetics(url, model, station, origin, source, cache_path=None):
     else:
         raise TypeError
 
-    filename = fullpath('data/greens_tensor/syngine/cache/', str(url2uuid(url)))
+    # where synthetics will be cached locally
+    filename = join(_check(cache_path), str(url2uuid(url)))
+
     if exists(filename):
         return filename
     elif exists(filename+'.zip'):
@@ -203,4 +201,17 @@ def get_synthetics_syngine(url, model, station, origin, mt):
     return synthetics
 
 
+
+def _check(path):
+    try:
+       assert path is not None
+       assert os.access(path, os.W_OK)
+    except:
+        try:
+            path = fullpath('data/greens_tensor/syngine/cache/')
+            assert os.access(path, os.W_OK)
+        except:
+            path = abspath('./syngine/cache')
+            os.makedirs(path, exists_ok=True)
+    return path
 


### PR DESCRIPTION
Includes the following changes to how syngine Green's functions are cached locally
- adds new ``cache_path`` option to ``syngine.Client()``
- if ``cache_path`` is not given, then attempts to download to MTUQ install directory (`mtuq/data/greens_tensor/syngine/cache`)
- if MTUQ install directory is not writeable, then attempts to download to current working directory (``./syngine/cache``)
- removes ``SYNGINE_CAHCE`` environment variable