### PR TITLE
Update to double-couple plots (random-grid compatibility)

### DIFF
--- a/mtuq/graphics/__init__.py
+++ b/mtuq/graphics/__init__.py
@@ -20,7 +20,8 @@ from mtuq.graphics.uq.vw import\
     _plot_vw, _product_vw
 
 from mtuq.graphics.uq.double_couple import\
-    plot_misfit_dc, plot_likelihood_dc, plot_marginal_dc, _plot_dc
+    plot_misfit_dc, plot_likelihood_dc, plot_marginal_dc, _plot_dc, \
+    plot_variance_reduction_dc
 
 from mtuq.graphics.uq.force import\
     plot_misfit_force, plot_likelihood_force, plot_marginal_force,\

--- a/mtuq/graphics/uq/_matplotlib.py
+++ b/mtuq/graphics/uq/_matplotlib.py
@@ -24,7 +24,7 @@ def cbformat(st, pos):
 # It should behave as similarly as possible to the GMT backend 
 # and take the same input arguments
 def _plot_lune_matplotlib(filename, longitude, latitude, values, 
-    best_vw=None, lune_array=None, colormap='viridis', plot_type='contour', **kwargs):
+    best_vw=None, lune_array=None, colormap='viridis', plot_type='contour', clip_interval=[0,100],**kwargs):
 
     """ Plots DataArray values on the eigenvalue lune (requires matplotlib)
 
@@ -61,6 +61,9 @@ def _plot_lune_matplotlib(filename, longitude, latitude, values,
     if _nothing_to_plot(values):
         return
     
+    if not isinstance(clip_interval, list) or len(clip_interval) != 2:
+        raise Exception('clip_interval must be a list of two floats')
+
     _development_warning()
 
     # Check plot_type. Can be either contour or colormesh
@@ -75,9 +78,9 @@ def _plot_lune_matplotlib(filename, longitude, latitude, values,
     x, y = _hammer_projection(x, y)
 
     # Plot data
-    # Use the percentile method to filter out outliers (Will alway clip the 10% greater values)
+    # Use the percentile method to filter out outliers based on clip_interval (in percentage)
     if plot_type == 'colormesh':
-        vmin, vmax = np.nanpercentile(np.asarray(values), [0,75])
+        vmin, vmax = np.nanpercentile(np.asarray(values), clip_interval)
         im = ax.pcolormesh(x, y, values, cmap=colormap, vmin=vmin, vmax=vmax, shading='nearest', zorder=10)
     elif plot_type == 'contour':
         # Plot using contourf
@@ -143,7 +146,8 @@ def _plot_lune_matplotlib(filename, longitude, latitude, values,
     pyplot.savefig(filename, dpi=300)
     pyplot.close()
 
-def _plot_force_matplotlib(filename, phi, h, values, best_force=None, colormap='viridis', title=None, plot_type='contour', **kwargs):
+def _plot_force_matplotlib(filename, phi, h, values, best_force=None, colormap='viridis', 
+                           title=None, plot_type='contour', clip_interval=[0,100], **kwargs):
     """ Plots DataArray values on the force sphere (requires matplotlib)
 
     .. rubric :: Keyword arguments
@@ -175,6 +179,9 @@ def _plot_force_matplotlib(filename, phi, h, values, best_force=None, colormap='
 
     if _nothing_to_plot(values):
         return
+
+    if not isinstance(clip_interval, list) or len(clip_interval) != 2:
+        raise Exception('clip_interval must be a list of two floats')
 
     _development_warning()
 
@@ -210,7 +217,7 @@ def _plot_force_matplotlib(filename, phi, h, values, best_force=None, colormap='
         x2, y2 = np.meshgrid(lon2, latitude)
         x1, y1 = _hammer_projection(x1, y1)
         x2, y2 = _hammer_projection(x2, y2)
-        vmin, vmax = np.nanpercentile(np.asarray(values), [0,75])
+        vmin, vmax = np.nanpercentile(np.asarray(values), clip_interval)
         im = ax.pcolormesh(x1, y1, values1, cmap=colormap, vmin=vmin, vmax=vmax, shading='auto', zorder=10)
         im = ax.pcolormesh(x2, y2, values2, cmap=colormap, vmin=vmin, vmax=vmax, shading='auto', zorder=10)
 
@@ -266,24 +273,26 @@ def _plot_force_matplotlib(filename, phi, h, values, best_force=None, colormap='
 
 
 def _plot_dc_matplotlib(filename, coords, 
-    values_h_kappa, values_sigma_kappa, values_sigma_h,
-    title=None, best_dc=None,  figsize=(8., 8.), fontsize=14, **kwargs):
+    values_h_kappa, values_sigma_kappa, values_sigma_h, colormap='viridis',
+    title=None, best_dc=None, plot_colorbar=True, figsize=(8., 8.), fontsize=14, clip_interval=[0,100],**kwargs):
+
+    if not isinstance(clip_interval, list) or len(clip_interval) != 2:
+        raise Exception('clip_interval must be a list of two floats')
 
     _development_warning()
 
-    colormap = kwargs.get('colormap', 'viridis')
-
-    # prepare axes
+    # Prepare axes
     fig, axes = pyplot.subplots(2, 2,
         figsize=figsize,
-        )
+    )
 
     pyplot.subplots_adjust(
         wspace=0.4,
         hspace=0.4,
-        )
+        right=0.88
+    )
 
-    # parse colormap
+    # Parse colormap
     if exists(_cpt_path(colormap)):
        colormap = read_cpt(_cpt_path(colormap))
 

--- a/mtuq/graphics/uq/double_couple.py
+++ b/mtuq/graphics/uq/double_couple.py
@@ -363,7 +363,6 @@ def _variance_reduction_dc_regular(da, data_norm):
     return variance_reduction.assign_attrs({
         'best_mt': _min_mt(da),
         'best_dc': _min_dc(da),
-        'lune_array': _lune_array(da),
         })
 
 def _variance_reduction_dc_random(df, data_norm, **kwargs):

--- a/mtuq/graphics/uq/double_couple.py
+++ b/mtuq/graphics/uq/double_couple.py
@@ -44,7 +44,7 @@ def plot_misfit_dc(filename, ds, **kwargs):
         misfit = _misfit_dc_regular(ds)
         
     elif issubclass(type(ds), DataFrame):
-        misfit = _misfit_dc_random(ds)
+        misfit = _misfit_dc_random(ds , **kwargs)
 
     _plot_dc(filename, misfit, **kwargs)
 
@@ -82,7 +82,7 @@ def plot_likelihood_dc(filename, ds, var, **kwargs):
         likelihoods = _likelihoods_dc_regular(ds, var)
 
     elif issubclass(type(ds), DataFrame):
-        likelihoods = _likelihoods_dc_random(ds, var)
+        likelihoods = _likelihoods_dc_random(ds, var, **kwargs)
 
     _plot_dc(filename, likelihoods, **kwargs)
 
@@ -120,7 +120,7 @@ def plot_marginal_dc(filename, ds, var, **kwargs):
         marginals = _marginals_dc_regular(ds, var)
 
     elif issubclass(type(ds), DataFrame):
-        marginals = _marginals_dc_random(ds, var)
+        marginals = _marginals_dc_random(ds, var, **kwargs)
 
     _plot_dc(filename, marginals, **kwargs)
 
@@ -158,7 +158,7 @@ def plot_variance_reduction_dc(filename, ds, data_norm, **kwargs):
         variance_reduction = _variance_reduction_dc_regular(ds, data_norm)
 
     elif issubclass(type(ds), DataFrame):
-        variance_reduction = _variance_reduction_dc_random(ds, data_norm)
+        variance_reduction = _variance_reduction_dc_random(ds, data_norm, **kwargs)
 
     _plot_dc(filename, variance_reduction, **kwargs)
 
@@ -419,16 +419,16 @@ def _max_dc(da):
     return dc_vals
 
 
-def _bin_dc_regular(df, handle, npts=25, **kwargs):
+def _bin_dc_regular(df, handle, nbins=25, **kwargs):
     """Bins irregularly-spaced moment tensor orientations into regular grids for plotting."""
     # Orientation bins
     kappa_min, kappa_max = 0, 360
     sigma_min, sigma_max = -90, 90
     h_min, h_max = 0, 1
 
-    kappa_edges = np.linspace(kappa_min, kappa_max, npts + 1)
-    sigma_edges = np.linspace(sigma_min, sigma_max, npts + 1)
-    h_edges = np.linspace(h_min, h_max, npts + 1)
+    kappa_edges = np.linspace(kappa_min, kappa_max, nbins + 1)
+    sigma_edges = np.linspace(sigma_min, sigma_max, nbins + 1)
+    h_edges = np.linspace(h_min, h_max, nbins + 1)
 
     kappa_centers = 0.5 * (kappa_edges[:-1] + kappa_edges[1:])
     sigma_centers = 0.5 * (sigma_edges[:-1] + sigma_edges[1:])
@@ -445,9 +445,9 @@ def _bin_dc_regular(df, handle, npts=25, **kwargs):
     h_indices = np.digitize(h_vals, h_edges) - 1
 
     # Ensure indices are within valid range
-    kappa_indices = np.clip(kappa_indices, 0, npts - 1)
-    sigma_indices = np.clip(sigma_indices, 0, npts - 1)
-    h_indices = np.clip(h_indices, 0, npts - 1)
+    kappa_indices = np.clip(kappa_indices, 0, nbins - 1)
+    sigma_indices = np.clip(sigma_indices, 0, nbins - 1)
+    h_indices = np.clip(h_indices, 0, nbins - 1)
 
     # Add bin indices to DataFrame
     df = df.copy()
@@ -460,7 +460,7 @@ def _bin_dc_regular(df, handle, npts=25, **kwargs):
     grouped = df.groupby(['kappa_idx', 'sigma_idx', 'h_idx'])
 
     # Initialize the output array with appropriate data type
-    binned = np.full((npts, npts, npts), np.nan)
+    binned = np.full((nbins, nbins, nbins), np.nan)
 
     # Process each group
     for (k_idx, s_idx, h_idx), group in grouped:


### PR DESCRIPTION
The changes in this PR are mostly focused on improving on the current implementation of the double-couple "map" figures. 
It also fixes an improper handling of color-clipping that was introduced with the full MTUQ Matplotlib visualization backend.

* added helper functions `_misfit_dc_random`, `_likelihoods_dc_random`, `_marginals_dc_random`, and `_variance_reduction_dc_random`, in order to generate binned maps to results stored in `MTUQDataFrame`.
* introduced `clip_interval`, that allows controlling percentile limits of the color-scale (mostly useful for CMA-ES)
* added optional colorbar on DC plots (existed in Lune and Force plots, but not DC up until this update)

A few changes are extended to the other plotting methods (all the `clip_interval` related changes). 

🛠 **Note**: tentative merge date -- Nov 25th 2024, unless some concerns are raised or receiving feedbacks 🛠

