### PR TITLE
Added **kwargs to `get_greens_tensors` method.

### DIFF
--- a/mtuq/io/clients/syngine.py
+++ b/mtuq/io/clients/syngine.py
@@ -59,7 +59,7 @@ class Client(ClientBase):
         self.cache_path = cache_path
 
 
-    def get_greens_tensors(self, stations=[], origins=[], verbose=False):
+    def get_greens_tensors(self, stations=[], origins=[], verbose=False, **kwargs):
         """ Downloads Green's tensors
 
         Returns a ``GreensTensorList`` in which each element corresponds to a


### PR DESCRIPTION
Running an example upon fresh install of MTUQ, following the syngine client rework yield the following error:

```bash
❯ python GridSearch.DoubleCouple.py
Reading data...

Processing data...

Reading Greens functions...

Traceback (most recent call last):
  File "/Users/julienthurin/Documents/GitHub/mtuq/examples/GridSearch.DoubleCouple.py", line 150, in <module>
    greens = download_greens_tensors(stations, origin, model)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/julienthurin/Documents/GitHub/mtuq/mtuq/io/clients/syngine.py", line 182, in download_greens_tensors
    return client.get_greens_tensors(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This minor change fixes this unintended behavior.