### PR TITLE
Minor bugfix to account for only 12 columns in weight file

### DIFF
--- a/mtuq/util/cap.py
+++ b/mtuq/util/cap.py
@@ -138,9 +138,9 @@ class WeightParser(object):
             statics[_code]['body_wave_Z'] = 0.
             statics[_code]['body_wave_R'] = 0.
 
-            statics[_code]['surface_wave_Z'] = float(row[11])
-            statics[_code]['surface_wave_R'] = float(row[11])
-            statics[_code]['surface_wave_T'] = float(row[12])
+            statics[_code]['surface_wave_Z'] = float(row[10])
+            statics[_code]['surface_wave_R'] = float(row[10])
+            statics[_code]['surface_wave_T'] = float(row[11])
 
         return statics
 


### PR DESCRIPTION
Hello,

I believe that at one point the weights files had 13 columns, and at some point this changed to only 12. I have updated the parse_statistics function to read in the proper columns for static time shifts.

Thanks,
Amanda