### PR TITLE
New utility function to generate a polarities array from a dictionary.

### DIFF
--- a/examples/Waveforms+Polarities.py
+++ b/examples/Waveforms+Polarities.py
@@ -10,7 +10,7 @@ from mtuq.grid import FullMomentTensorGridSemiregular
 from mtuq.grid_search import grid_search
 from mtuq.misfit import WaveformMisfit, PolarityMisfit
 from mtuq.process_data import ProcessData
-from mtuq.util import fullpath, merge_dicts, save_json
+from mtuq.util import fullpath, merge_dicts, save_json, polarities_array_from_dict
 from mtuq.util.cap import parse_station_codes, Trapezoid
 
 
@@ -218,9 +218,7 @@ if __name__=='__main__':
     if comm.rank==0:
         print('Evaluating polarity misfit...\n')
 
-    polarities = np.zeros(len(stations))
-    for _i, station in enumerate(stations):
-        polarities[_i] = polarities_dict[station.station]
+    polarities = polarities_array_from_dict(polarities_dict, stations)
         
     results_polarity = grid_search(
         polarities, greens_bw, polarity_misfit, origin, grid)

--- a/examples/Waveforms+Polarities.py
+++ b/examples/Waveforms+Polarities.py
@@ -8,9 +8,9 @@ from mtuq.event import Origin
 from mtuq.graphics import plot_data_greens2, plot_beachball, plot_polarities, plot_misfit_lune
 from mtuq.grid import FullMomentTensorGridSemiregular
 from mtuq.grid_search import grid_search
-from mtuq.misfit import WaveformMisfit, PolarityMisfit
+from mtuq.misfit import WaveformMisfit, PolarityMisfit, polarities_from_dict
 from mtuq.process_data import ProcessData
-from mtuq.util import fullpath, merge_dicts, save_json, polarities_array_from_dict
+from mtuq.util import fullpath, merge_dicts, save_json
 from mtuq.util.cap import parse_station_codes, Trapezoid
 
 
@@ -108,7 +108,7 @@ if __name__=='__main__':
         "NSKI": +1,
         "PERI": +1,
         "SOLD":  0,
-        "TUPA":  1,
+        "TUPA": +1,
         }
 
 
@@ -218,7 +218,7 @@ if __name__=='__main__':
     if comm.rank==0:
         print('Evaluating polarity misfit...\n')
 
-    polarities = polarities_array_from_dict(polarities_dict, stations)
+    polarities = polarities_from_dict(polarities_dict, stations)
         
     results_polarity = grid_search(
         polarities, greens_bw, polarity_misfit, origin, grid)

--- a/mtuq/misfit/__init__.py
+++ b/mtuq/misfit/__init__.py
@@ -1,7 +1,7 @@
 
 from mtuq.misfit.waveform import WaveformMisfit
 
-from mtuq.misfit.polarity import PolarityMisfit
+from mtuq.misfit.polarity import PolarityMisfit, polarities_from_dict
 
 #
 # for backward compatibility

--- a/mtuq/misfit/polarity.py
+++ b/mtuq/misfit/polarity.py
@@ -362,6 +362,26 @@ def _model_type(greens):
 
     return model_type
 
+def polarities_from_dict(dict_polarity, stations):
+    """
+    Converts a dictionary of polarities to a NumPy array based on the provided stations.
+
+    Args:
+        dict_polarity (dict): Dictionary mapping station names to polarity values.
+        stations (list): List of station objects.
+
+    Returns:
+        numpy.ndarray: NumPy array containing polarity values corresponding to the stations.
+    """
+
+    polarities = np.zeros(len(stations))
+    for i, station in enumerate(stations):
+        station_name = station.station
+        if station_name in dict_polarity:
+            polarities[i] = dict_polarity[station_name]
+        else:
+            print(f'Station {station_name} not found in the dictionary')
+    return polarities
 
 def _check(greens, method):
     return

--- a/mtuq/util/__init__.py
+++ b/mtuq/util/__init__.py
@@ -352,26 +352,28 @@ def dataarray_idxmax(da, warnings=True):
             da = da[0]
     return da.coords
 
-def sort_polarities(dict_polarity, data, polarities):
+def polarities_array_from_dict(dict_polarity, stations):
     """
-    Assigns polarity values from dict_polarity to polarities array based on station names in data (Obspy streams).
+    Based on:
+    polarities = np.zeros(len(stations))
+    for _i, station in enumerate(stations):
+        polarities[_i] = polarities_dict[station.station]
 
     Args:
         dict_polarity (dict): Dictionary mapping station names to polarity values.
-        data (list): List of Obspy streams.
-        polarities (numpy.ndarray): NumPy array to store polarity values.
+        stations (list): List of station objects.
 
     Returns:
-        numpy.ndarray: Updated polarities array.
+        numpy.ndarray: NumPy array containing polarity values corresponding to the stations.
     """
 
-    for i, stream in enumerate(data):
-        station_name = stream[0].stats.station
+    polarities = np.zeros(len(stations))
+    for i, station in enumerate(stations):
+        station_name = station.station
         if station_name in dict_polarity:
             polarities[i] = dict_polarity[station_name]
         else:
-            warn(f'Station {station_name} not found in the dictionary')
-
+            print(f'Station {station_name} not found in the dictionary')
     return polarities
 
 def defaults(kwargs, defaults):

--- a/mtuq/util/__init__.py
+++ b/mtuq/util/__init__.py
@@ -352,30 +352,6 @@ def dataarray_idxmax(da, warnings=True):
             da = da[0]
     return da.coords
 
-def polarities_array_from_dict(dict_polarity, stations):
-    """
-    Based on:
-    polarities = np.zeros(len(stations))
-    for _i, station in enumerate(stations):
-        polarities[_i] = polarities_dict[station.station]
-
-    Args:
-        dict_polarity (dict): Dictionary mapping station names to polarity values.
-        stations (list): List of station objects.
-
-    Returns:
-        numpy.ndarray: NumPy array containing polarity values corresponding to the stations.
-    """
-
-    polarities = np.zeros(len(stations))
-    for i, station in enumerate(stations):
-        station_name = station.station
-        if station_name in dict_polarity:
-            polarities[i] = dict_polarity[station_name]
-        else:
-            print(f'Station {station_name} not found in the dictionary')
-    return polarities
-
 def defaults(kwargs, defaults):
     for key in defaults:
         if key not in kwargs:

--- a/mtuq/util/__init__.py
+++ b/mtuq/util/__init__.py
@@ -352,6 +352,27 @@ def dataarray_idxmax(da, warnings=True):
             da = da[0]
     return da.coords
 
+def sort_polarities(dict_polarity, data, polarities):
+    """
+    Assigns polarity values from dict_polarity to polarities array based on station names in data (Obspy streams).
+
+    Args:
+        dict_polarity (dict): Dictionary mapping station names to polarity values.
+        data (list): List of Obspy streams.
+        polarities (numpy.ndarray): NumPy array to store polarity values.
+
+    Returns:
+        numpy.ndarray: Updated polarities array.
+    """
+
+    for i, stream in enumerate(data):
+        station_name = stream[0].stats.station
+        if station_name in dict_polarity:
+            polarities[i] = dict_polarity[station_name]
+        else:
+            warn(f'Station {station_name} not found in the dictionary')
+
+    return polarities
 
 def defaults(kwargs, defaults):
     for key in defaults:

--- a/setup/code_generator.py
+++ b/setup/code_generator.py
@@ -513,7 +513,7 @@ WaveformsPolaritiesMisfit="""
         "NSKI": +1,
         "PERI": +1,
         "SOLD":  0,
-        "TUPA":  1,
+        "TUPA": +1,
         }
 
 
@@ -1573,7 +1573,7 @@ WrapUp_WaveformsPolarities="""
     if comm.rank==0:
         print('Evaluating polarity misfit...\\n')
 
-    polarities = polarities_array_from_dict(polarities_dict, stations)
+    polarities = polarities_from_dict(polarities_dict, stations)
         
     results_polarity = grid_search(
         polarities, greens_bw, polarity_misfit, origin, grid)
@@ -1988,9 +1988,7 @@ if __name__=='__main__':
             'plot_beachball',
             'plot_beachball, plot_polarities',
             'from mtuq.misfit import Misfit',
-            'from mtuq.misfit import WaveformMisfit, PolarityMisfit',
-            'from mtuq.util import fullpath, merge_dicts, save_json',
-            'from mtuq.util import fullpath, merge_dicts, save_json, polarities_array_from_dict',
+            'from mtuq.misfit import WaveformMisfit, PolarityMisfit, polarities_from_dict',
             ))
         file.write(Docstring_WaveformsPolarities)
         file.write(Paths_Syngine)

--- a/setup/code_generator.py
+++ b/setup/code_generator.py
@@ -1573,9 +1573,7 @@ WrapUp_WaveformsPolarities="""
     if comm.rank==0:
         print('Evaluating polarity misfit...\\n')
 
-    polarities = np.zeros(len(stations))
-    for _i, station in enumerate(stations):
-        polarities[_i] = polarities_dict[station.station]
+    polarities = polarities_array_from_dict(polarities_dict, stations)
         
     results_polarity = grid_search(
         polarities, greens_bw, polarity_misfit, origin, grid)
@@ -1991,6 +1989,8 @@ if __name__=='__main__':
             'plot_beachball, plot_polarities',
             'from mtuq.misfit import Misfit',
             'from mtuq.misfit import WaveformMisfit, PolarityMisfit',
+            'from mtuq.util import fullpath, merge_dicts, save_json',
+            'from mtuq.util import fullpath, merge_dicts, save_json, polarities_array_from_dict',
             ))
         file.write(Docstring_WaveformsPolarities)
         file.write(Paths_Syngine)


### PR DESCRIPTION
This functions addresses a need to provide a sorted array for polarities values [-1,0,1] for each stations, from a polarity dictionary.

From the `Waveforms+Polarities.py` example:

```python3
    polarities_dict = {
        "BMR":   0,
        "DIV":  +1,
        "EYAK": +1,
        "PAX":  +1,
        ...
        "PERI": +1,
        "SOLD":  0,
        "TUPA": +1,
        }

    polarities = polarities_array_from_dict(polarities_dict, stations)
```
it replaces the following loop:
```python3
    polarities = np.zeros(len(stations))
    for _i, station in enumerate(stations):
        polarities[_i] = polarities_dict[station.station]
```

and adds warning prints if there is a discrepancy between the names in `stations` and `polarities_dict`.

Mostly straightforward PR, but I am happy to get any feedback if you think it is too redundant (@rmodrak, @ammcpherson, @SeismoFelix).

_Planning to merge en Feb 26th._