### PR TITLE
Misc fixes : Synthetic plotting, windowing and padding arguments fixes, forward example.

### DIFF
--- a/docs/user_guide/06.rst
+++ b/docs/user_guide/06.rst
@@ -8,6 +8,7 @@ Miscellaneous
 
    06/grid_structures
    06/moment_tensor_and_force_grids
+   06/direct_evaluation
    06/reading_writing_results
    06/trace_attributes
    06/plotting_trace_attributes

--- a/docs/user_guide/06/direct_evaluation.rst
+++ b/docs/user_guide/06/direct_evaluation.rst
@@ -1,0 +1,44 @@
+Direct source evaluation
+========================
+
+Instead of searching over a grid, it is sometimes useful to evaluate a single, fixed moment tensor — for example, to forward-model waveforms, verify a published solution, or inspect fits before running a full inversion.
+
+The example `examples/DirectEvaluation.py <https://github.com/mtuqorg/mtuq/blob/master/examples/DirectEvaluation.py>`_ demonstrates this workflow.  The source is defined directly from its moment tensor components, and ``from_mij`` converts them to the lune parameters needed by the plotting functions:
+
+.. code::
+
+    from mtuq.event import MomentTensor
+    from mtuq.util.math import from_mij
+
+    mt_dict = {
+        'Mrr': -5800435174432632.0,
+        'Mtt':   789342714264084.5,
+        'Mpp':  5011092460168549.0,
+        'Mrt':  3034156721905327.0,
+        'Mrp':  2110077787951300.2,
+        'Mtp':  2602039428905879.0,
+        }
+
+    mt_array  = list(mt_dict.values())
+    lune_dict = dict(zip(('rho', 'v', 'w', 'kappa', 'sigma', 'h'), from_mij(mt_array)))
+    mt        = MomentTensor(mt_array)
+
+    plot_data_greens2(event_id + '_waveforms.png',
+        data_bw, data_sw, greens_bw, greens_sw,
+        process_bw, process_sw, misfit_bw, misfit_sw,
+        stations, origin, mt, lune_dict)
+
+    plot_beachball(event_id + '_beachball.png', mt, stations, origin)
+
+If the source is known in terms of fault geometry rather than Mij components, ``to_mij`` and ``to_rho`` can be used to convert:
+
+.. code::
+
+    from mtuq.util.math import to_mij, to_rho
+
+    Mw, strike, dip, rake = 4.5, 230., 40., -10.
+    mt_array = to_mij(to_rho(Mw), 0., 0., strike, rake, np.cos(np.deg2rad(dip)))
+
+Setting ``v = 0`` and ``w = 0`` in the ``to_mij`` call constrains the source to be a pure double couple.  For a full moment tensor, supply non-zero lune coordinates instead (see `Moment tensor and force grids <https://mtuqorg.github.io/mtuq/user_guide/06/moment_tensor_and_force_grids.html>`_) or use the `from_mij` function to convert Mij components to lune parameters.
+
+You can find relevant utility functions in the ``mtuq.util.math`` module.

--- a/examples/DirectEvaluation.py
+++ b/examples/DirectEvaluation.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+
+import os
+import numpy as np
+
+from mtuq import read, download_greens
+from mtuq.event import MomentTensor, Origin
+from mtuq.graphics import plot_data_greens2, plot_beachball
+from mtuq.misfit import Misfit
+from mtuq.process_data import ProcessData
+from mtuq.util import fullpath, merge_dicts, save_json
+from mtuq.util.cap import parse_station_codes, Trapezoid
+from mtuq.util.math import from_mij, to_mij, to_rho
+
+
+if __name__=='__main__':
+    #
+    # Helper code for evaluating synthetic waveforms for a single fixed source.
+    #
+    # USAGE
+    #   python DirectEvaluation.py
+    #
+
+    path_data=    fullpath('data/examples/20090407201255351/*.[zrt]')
+    path_weights= fullpath('data/examples/20090407201255351/weights.dat')
+    event_id=     '20090407201255351'
+    model=        'ak135'
+
+
+    #
+    # Body and surface wave measurements will be made separately
+    #
+
+    process_bw = ProcessData(
+        filter_type='Bandpass',
+        freq_min= 0.1,
+        freq_max= 0.333,
+        pick_type='taup',
+        taup_model=model,
+        window_type='body_wave',
+        window_length=15.,
+        capuaf_file=path_weights,
+        )
+
+    process_sw = ProcessData(
+        filter_type='Bandpass',
+        freq_min=0.025,
+        freq_max=0.0625,
+        pick_type='taup',
+        taup_model=model,
+        window_type='surface_wave',
+        window_length=150.,
+        capuaf_file=path_weights,
+        )
+
+
+    #
+    # For our objective function, we will use a sum of body and surface wave
+    # contributions
+    #
+
+    misfit_bw = Misfit(
+        norm='L2',
+        time_shift_min=-2.,
+        time_shift_max=+2.,
+        time_shift_groups=['ZR'],
+        normalize=True,
+        )
+
+    misfit_sw = Misfit(
+        norm='L2',
+        time_shift_min=-10.,
+        time_shift_max=+10.,
+        time_shift_groups=['ZR','T'],
+        normalize=True,
+        )
+
+
+    #
+    # User-supplied weights control how much each station contributes to the
+    # objective function
+    #
+
+    station_id_list = parse_station_codes(path_weights)
+
+
+    #
+    # Define the source directly from moment tensor components (Mrr, Mtt, Mpp, Mrt, Mrp, Mtp).
+    # Alternatively, fault geometry can be converted using to_mij (see commented block below).
+    #
+
+    mt_dict = {
+        'Mrr': -5800435174432632.0,
+        'Mtt':   789342714264084.5,
+        'Mpp':  5011092460168549.0,
+        'Mrt':  3034156721905327.0,
+        'Mrp':  2110077787951300.2,
+        'Mtp':  2602039428905879.0,
+        }
+
+    mt_array = list(mt_dict.values())
+
+    # To define the source from fault geometry instead:
+    # Mw, strike, dip, rake = 4.5, 230., 40., -10.
+    # mt_array = to_mij(to_rho(Mw), 0., 0., strike, rake, np.cos(np.deg2rad(dip)))
+
+    lune_dict = dict(zip(('rho', 'v', 'w', 'kappa', 'sigma', 'h'), from_mij(mt_array)))
+
+    mt = MomentTensor(mt_array)
+
+    wavelet = Trapezoid(magnitude=4.5)
+
+
+    #
+    # Origin time and location will be fixed. For an example in which they
+    # vary, see examples/GridSearch.DoubleCouple+Magnitude+Depth.py
+    #
+    # See also Dataset.get_origins(), which attempts to create Origin objects
+    # from waveform metadata
+    #
+
+    origin = Origin({
+        'time': '2009-04-07T20:12:55.000000Z',
+        'latitude': 61.454200744628906,
+        'longitude': -149.7427978515625,
+        'depth_in_m': 33033.599853515625,
+        })
+
+
+    #
+    # The main I/O work starts now
+    #
+
+    print('Reading data...\n')
+    data = read(path_data, format='sac',
+        event_id=event_id,
+        station_id_list=station_id_list,
+        tags=['units:m', 'type:velocity'])
+
+    data.sort_by_distance()
+    stations = data.get_stations()
+
+    print('Processing data...\n')
+    data_bw = data.map(process_bw)
+    data_sw = data.map(process_sw)
+
+    print('Reading Greens functions...\n')
+    greens = download_greens(stations, origin, model)
+
+    print('Processing Greens functions...\n')
+    greens.convolve(wavelet)
+    greens_bw = greens.map(process_bw)
+    greens_sw = greens.map(process_sw)
+
+
+    #
+    # Generating synthetics
+    #
+
+    syn_bw = greens_bw.get_synthetics(mt, components=['Z', 'R'])
+    syn_sw = greens_sw.get_synthetics(mt, components=['Z', 'R', 'T'])
+
+    syn_bw.write(event_id+'DC_synthetics_bw.sac', format='sac')
+    syn_sw.write(event_id+'DC_synthetics_sw.sac', format='sac')
+
+
+    print('Generating figures...\n')
+
+    plot_data_greens2(event_id+'DC_waveforms.png',
+        data_bw, data_sw, greens_bw, greens_sw, process_bw, process_sw,
+        misfit_bw, misfit_sw, stations, origin, mt, lune_dict)
+
+    plot_beachball(event_id+'DC_beachball.png',
+        mt, stations, origin)
+
+
+    print('Saving results...\n')
+
+    mt_dict.update(lune_dict)
+    mt_dict.update({'Mw': mt.magnitude(), 'M0': mt.moment()})
+    save_json(event_id+'DC_solution.json', mt_dict)
+
+    print('\nFinished\n')

--- a/examples/DirectEvaluation.py
+++ b/examples/DirectEvaluation.py
@@ -21,6 +21,7 @@ if __name__=='__main__':
     #   python DirectEvaluation.py
     #
 
+
     path_data=    fullpath('data/examples/20090407201255351/*.[zrt]')
     path_weights= fullpath('data/examples/20090407201255351/weights.dat')
     event_id=     '20090407201255351'
@@ -112,7 +113,7 @@ if __name__=='__main__':
 
 
     #
-    # Origin time and location will be fixed. For an example in which they
+    # Origin time and location will be fixed. For an example in which they 
     # vary, see examples/GridSearch.DoubleCouple+Magnitude+Depth.py
     #
     # See also Dataset.get_origins(), which attempts to create Origin objects

--- a/mtuq/__init__.py
+++ b/mtuq/__init__.py
@@ -40,7 +40,15 @@ from mtuq.process_data import ProcessData
 #from mtuq.grid_search import grid_search
 
 
-from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points
+def _iter_group(group):
+    # pkg_resources.iter_entry_points(group) replacement using importlib.metadata.
+    try:
+        return entry_points(group=group)
+    # compatibility with older entry_points() behavior which returned a dict-like object keyed by group
+    except TypeError:
+        return entry_points().get(group, [])
+
 from mtuq.io.clients.syngine import download_greens
 
 
@@ -56,8 +64,8 @@ download_greens_tensors = download_greens
 
 def _greens_tensor_clients():
     clients = {}
-    for entry_point in iter_entry_points('greens_tensor_clients'):
-        clients[entry_point.name] = entry_point.load()
+    for ep in _iter_group("greens_tensor_clients"):
+        clients[ep.name] = ep.load()
     return clients
 
 
@@ -82,8 +90,8 @@ def open_db(path_or_url='', format='', **kwargs):
 
 def _readers():
     readers = {}
-    for entry_point in iter_entry_points('readers'):
-        readers[entry_point.name] = entry_point.load()
+    for ep in _iter_group("readers"):
+        readers[ep.name] = ep.load()
     return readers
 
 

--- a/mtuq/graphics/beachball.py
+++ b/mtuq/graphics/beachball.py
@@ -553,7 +553,7 @@ def _plot_beachball_matplotlib(filename, mt_arrays, stations=None, origin=None, 
 
     if filename:
         pyplot.tight_layout(pad=-0.8)
-        fig.savefig(filename, dpi=300)
+        fig.savefig(filename, dpi=300, **kwargs)
         pyplot.close(fig)
     return
 

--- a/mtuq/graphics/header.py
+++ b/mtuq/graphics/header.py
@@ -157,10 +157,10 @@ class TextBlock(HeaderBlock):
 class MomentTensorFigureBlock(HeaderBlock):
     """Block for displaying moment tensor beachball figures."""
 
-    def __init__(self, diameter_scale=0.75, backend=_plot_beachball_matplotlib, color='gray'):
+    def __init__(self, diameter_scale=0.75, backend=_plot_beachball_matplotlib, beachball_color='gray'):
         self.diameter_scale = diameter_scale
         self.backend = backend
-        self.color = color
+        self.beachball_color = beachball_color
 
     def render(self, ax, info, px, py, *, height: float, width: float,
                margin_left: float, margin_top: float, style: HeaderStyle):
@@ -176,7 +176,7 @@ class MomentTensorFigureBlock(HeaderBlock):
             inset_ax.set_yticks([])
             inset_ax.set_frame_on(False)
             plot_beachball(None, mt, None, None, fig=inset_ax.figure, ax=inset_ax,
-                           backend=self.backend, color=self.color)
+                           backend=self.backend, color=self.beachball_color)
             inset_ax.axis('off')
         else:
             # File-based rendering for other backends
@@ -186,7 +186,7 @@ class MomentTensorFigureBlock(HeaderBlock):
 
     def _render_via_file(self, ax, mt, xp, yp, diameter):
         """Helper method for file-based rendering."""
-        plot_beachball('tmp.png', mt, None, None, backend=self.backend, color=self.color)
+        plot_beachball('tmp.png', mt, None, None, backend=self.backend, color=self.beachball_color)
         img = pyplot.imread('tmp.png')
         self._cleanup_temp_files()
         ax.imshow(img, extent=(xp, xp+diameter, yp, yp+diameter))
@@ -451,10 +451,10 @@ def _station_counts(data_bw, data_sw, data_sw_supp):
 # =============================================================================
 # Header Factory Functions
 # =============================================================================
-def build_moment_tensor_header(info, color='gray'):
+def build_moment_tensor_header(info, beachball_color='gray'):
     """Build header layout for moment tensor inversion results."""
     blocks = [
-        MomentTensorFigureBlock(color=color),
+        MomentTensorFigureBlock(beachball_color=beachball_color),
         TextBlock('{event_name}  {latlon}  $M_w$ {magnitude:.2f}  {depth_label} {depth_str}', bold=False),
         TextBlock('model: {model}   solver: {solver}   misfit ({norm}): {best_misfit:.3e}', bold=False),
         TextBlock('{passband_line}', bold=False),
@@ -579,12 +579,12 @@ def create_moment_tensor_header(process_bw, process_sw, misfit_bw, misfit_sw,
                                data_bw=None, data_sw=None, mt_grid=None, event_name=None, **kwargs):
     """Create a complete moment tensor header"""
     process_sw_supp = kwargs.pop('process_sw_supp', None)
-    color = kwargs.pop('color', 'gray')
+    beachball_color = kwargs.pop('beachball_color', 'gray')
     header_info = prepare_moment_tensor_header_info(
         origin, mt, lune_dict, process_bw, process_sw, process_sw_supp,
         misfit_bw, misfit_sw, best_misfit_bw, best_misfit_sw, model, solver,
         data_bw=data_bw, data_sw=data_sw, mt_grid=mt_grid, event_name=event_name, **kwargs)
-    header = build_moment_tensor_header(header_info, color=color)
+    header = build_moment_tensor_header(header_info, beachball_color=beachball_color)
     return header, header_info
 
 

--- a/mtuq/graphics/header.py
+++ b/mtuq/graphics/header.py
@@ -156,12 +156,13 @@ class TextBlock(HeaderBlock):
 
 class MomentTensorFigureBlock(HeaderBlock):
     """Block for displaying moment tensor beachball figures."""
-    
-    def __init__(self, diameter_scale=0.75, backend=_plot_beachball_matplotlib):
+
+    def __init__(self, diameter_scale=0.75, backend=_plot_beachball_matplotlib, color='gray'):
         self.diameter_scale = diameter_scale
         self.backend = backend
-    
-    def render(self, ax, info, px, py, *, height: float, width: float, 
+        self.color = color
+
+    def render(self, ax, info, px, py, *, height: float, width: float,
                margin_left: float, margin_top: float, style: HeaderStyle):
         mt = info.mt
         diameter = self.diameter_scale * height
@@ -174,17 +175,18 @@ class MomentTensorFigureBlock(HeaderBlock):
             inset_ax.set_xticks([])
             inset_ax.set_yticks([])
             inset_ax.set_frame_on(False)
-            plot_beachball(None, mt, None, None, fig=inset_ax.figure, ax=inset_ax, backend=self.backend)
+            plot_beachball(None, mt, None, None, fig=inset_ax.figure, ax=inset_ax,
+                           backend=self.backend, color=self.color)
             inset_ax.axis('off')
         else:
             # File-based rendering for other backends
             self._render_via_file(ax, mt, xp, yp, diameter)
 
         return py  # no vertical change
-    
+
     def _render_via_file(self, ax, mt, xp, yp, diameter):
         """Helper method for file-based rendering."""
-        plot_beachball('tmp.png', mt, None, None, backend=self.backend)
+        plot_beachball('tmp.png', mt, None, None, backend=self.backend, color=self.color)
         img = pyplot.imread('tmp.png')
         self._cleanup_temp_files()
         ax.imshow(img, extent=(xp, xp+diameter, yp, yp+diameter))
@@ -449,10 +451,10 @@ def _station_counts(data_bw, data_sw, data_sw_supp):
 # =============================================================================
 # Header Factory Functions
 # =============================================================================
-def build_moment_tensor_header(info):
+def build_moment_tensor_header(info, color='gray'):
     """Build header layout for moment tensor inversion results."""
     blocks = [
-        MomentTensorFigureBlock(),
+        MomentTensorFigureBlock(color=color),
         TextBlock('{event_name}  {latlon}  $M_w$ {magnitude:.2f}  {depth_label} {depth_str}', bold=False),
         TextBlock('model: {model}   solver: {solver}   misfit ({norm}): {best_misfit:.3e}', bold=False),
         TextBlock('{passband_line}', bold=False),
@@ -577,11 +579,12 @@ def create_moment_tensor_header(process_bw, process_sw, misfit_bw, misfit_sw,
                                data_bw=None, data_sw=None, mt_grid=None, event_name=None, **kwargs):
     """Create a complete moment tensor header"""
     process_sw_supp = kwargs.pop('process_sw_supp', None)
+    color = kwargs.pop('color', 'gray')
     header_info = prepare_moment_tensor_header_info(
         origin, mt, lune_dict, process_bw, process_sw, process_sw_supp,
         misfit_bw, misfit_sw, best_misfit_bw, best_misfit_sw, model, solver,
         data_bw=data_bw, data_sw=data_sw, mt_grid=mt_grid, event_name=event_name, **kwargs)
-    header = build_moment_tensor_header(header_info)
+    header = build_moment_tensor_header(header_info, color=color)
     return header, header_info
 
 

--- a/mtuq/graphics/waveforms.py
+++ b/mtuq/graphics/waveforms.py
@@ -22,16 +22,17 @@ from obspy import Stream, Trace
 #
 
 def plot_waveforms1(
-        filename, 
+        filename,
         data,
         synthetics,
         stations,
         origin,
         header=None,
-        total_misfit=1., 
+        total_misfit=1.,
         normalize='maximum_amplitude',
         trace_label_writer=trace_label_writer,
         station_label_writer=station_label_writer,
+        syn_color='red',
         ):
 
     """ Creates data/synthetics comparison figure with 3 columns (Z, R, T)
@@ -78,9 +79,10 @@ def plot_waveforms1(
             pass
 
         # plot traces
-        _plot_stream(axes[ir], [1,2,3], ['Z','R','T'], 
+        _plot_stream(axes[ir], [1,2,3], ['Z','R','T'],
                   data[_i], synthetics[_i],
-                  normalize, factor, trace_label_writer, total_misfit)
+                  normalize, factor, trace_label_writer, total_misfit,
+                  syn_color=syn_color)
 
         ir += 1
 
@@ -90,7 +92,7 @@ def plot_waveforms1(
 
 
 def plot_waveforms2(
-        filename, 
+        filename,
         data_bw,
         data_sw,
         synthetics_bw,
@@ -98,11 +100,12 @@ def plot_waveforms2(
         stations,
         origin,
         header=None,
-        total_misfit_bw=1., 
-        total_misfit_sw=1., 
+        total_misfit_bw=1.,
+        total_misfit_sw=1.,
         normalize='maximum_amplitude',
         trace_label_writer=trace_label_writer,
         station_label_writer=station_label_writer,
+        syn_color='red',
         ):
 
 
@@ -161,12 +164,14 @@ def plot_waveforms2(
         # plot body wave traces
         _plot_stream(axes[ir], [1,2], ['Z','R'],
                      data_bw[_i], synthetics_bw[_i],
-                     normalize, factor_bw, trace_label_writer, total_misfit_bw)
+                     normalize, factor_bw, trace_label_writer, total_misfit_bw,
+                     syn_color=syn_color)
 
         # plot surface wave traces
         _plot_stream(axes[ir], [3,4,5], ['Z','R','T'],
                      data_sw[_i], synthetics_sw[_i],
-                     normalize, factor_sw, trace_label_writer, total_misfit_sw)
+                     normalize, factor_sw, trace_label_writer, total_misfit_sw,
+                     syn_color=syn_color)
 
         ir += 1
 
@@ -175,7 +180,7 @@ def plot_waveforms2(
 
 
 def plot_waveforms3(
-        filename, 
+        filename,
         data_bw,
         data_rayl,
         data_love,
@@ -185,12 +190,13 @@ def plot_waveforms3(
         stations,
         origin,
         header=None,
-        total_misfit_bw=1., 
-        total_misfit_rayl=1., 
+        total_misfit_bw=1.,
+        total_misfit_rayl=1.,
         total_misfit_love=1.,
         normalize='maximum_amplitude',
         trace_label_writer=trace_label_writer,
         station_label_writer=station_label_writer,
+        syn_color='red',
         ):
 
     """ Creates data/synthetics comparison figure with 5 columns 
@@ -259,19 +265,22 @@ def plot_waveforms3(
             pass
 
         # plot body waves
-        _plot_stream(axes[ir], [1,2], ['Z','R'], 
+        _plot_stream(axes[ir], [1,2], ['Z','R'],
                      data_bw[_i], synthetics_bw[_i],
-                     normalize, factor_bw, trace_label_writer, total_misfit_bw)
-        
+                     normalize, factor_bw, trace_label_writer, total_misfit_bw,
+                     syn_color=syn_color)
+
         # plot Rayleigh waves
         _plot_stream(axes[ir], [3,4], ['Z','R'],
                      data_rayl[_i], synthetics_rayl[_i],
-                     normalize, factor_rayl, trace_label_writer, total_misfit_rayl)
+                     normalize, factor_rayl, trace_label_writer, total_misfit_rayl,
+                     syn_color=syn_color)
 
         # plot Love waves
         _plot_stream(axes[ir], [5], ['T'],
                      data_love[_i], synthetics_love[_i],
-                     normalize, factor_love, trace_label_writer, total_misfit_love)
+                     normalize, factor_love, trace_label_writer, total_misfit_love,
+                     syn_color=syn_color)
 
         ir += 1
 
@@ -309,10 +318,11 @@ def plot_data_greens1(
     else:
         model = _get_tag(greens[0].tags, 'model')
         solver = _get_tag(greens[0].tags, 'solver')
+        color = kwargs.pop('color', 'gray')
 
         header = _prepare_header(
             model, solver, source, source_dict, origin,
-            process_data, misfit, total_misfit, data_sw=data)
+            process_data, misfit, total_misfit, data_sw=data, color=color)
 
     plot_waveforms1(filename,
         data, synthetics, stations, origin,
@@ -363,12 +373,13 @@ def plot_data_greens2(filename,
     else:
         model = _get_tag(greens_sw[0].tags, 'model')
         solver = _get_tag(greens_sw[0].tags, 'solver')
+        color = kwargs.pop('color', 'gray')
 
         header = _prepare_header(
             model, solver, source, source_dict, origin,
             process_data_bw, process_data_sw,
             misfit_bw, misfit_sw, total_misfit_bw, total_misfit_sw,
-            data_bw=data_bw, data_sw=data_sw)
+            data_bw=data_bw, data_sw=data_sw, color=color)
 
     plot_waveforms2(filename,
         data_bw, data_sw, synthetics_bw, synthetics_sw, stations, origin,
@@ -428,13 +439,14 @@ def plot_data_greens3(
     else:
         model = _get_tag(greens_bw[0].tags, 'model')
         solver = _get_tag(greens_bw[0].tags, 'solver')
+        color = kwargs.pop('color', 'gray')
 
         header = _prepare_header(
             model, solver, source, source_dict, origin,
             process_data_bw, process_data_rayl, misfit_bw, misfit_rayl,
             total_misfit_bw, total_misfit_rayl, best_misfit_sw_supp=total_misfit_love,
             misfit_sw_supp = misfit_love, data_bw=data_bw, data_sw=data_rayl,
-            data_sw_supp=data_love, process_sw_supp=process_data_love)
+            data_sw_supp=data_love, process_sw_supp=process_data_love, color=color)
 
     plot_waveforms3(filename,
         data_bw, data_rayl, data_love,
@@ -534,7 +546,8 @@ def _plot_stream(
     normalize='maximum_amplitude',
     amplitude_factor=None,
     trace_label_writer=None,
-    total_misfit=1.
+    total_misfit=1.,
+    syn_color='red',
     ):
 
     if normalize in [
@@ -580,7 +593,7 @@ def _plot_stream(
         elif amplitude_factor:
             ylim = [-amplitude_factor, +amplitude_factor]
 
-        _plot_trace(axis, dat, syn)
+        _plot_trace(axis, dat, syn, syn_color=syn_color)
 
         try:
             axis.set_ylim(*ylim)
@@ -593,7 +606,7 @@ def _plot_stream(
             pass
 
 
-def _plot_trace(axis, dat, syn, label=None):
+def _plot_trace(axis, dat, syn, label=None, syn_color='red'):
     """ Plots data and synthetics time series on current axes
     """
     if dat is None and syn is None:
@@ -613,7 +626,7 @@ def _plot_trace(axis, dat, syn, label=None):
 
         t,s = _time_series(syn)
 
-        axis.plot(t[:stop-start], s[start:stop], 'r', linewidth=1.25,
+        axis.plot(t[:stop-start], s[start:stop], color=syn_color, linewidth=1.25,
             clip_on=True, zorder=10)
 
 

--- a/mtuq/graphics/waveforms.py
+++ b/mtuq/graphics/waveforms.py
@@ -32,8 +32,9 @@ def plot_waveforms1(
         normalize='maximum_amplitude',
         trace_label_writer=trace_label_writer,
         station_label_writer=station_label_writer,
-        syn_color='red',
-        ):
+        dat_kwargs=None,
+        syn_kwargs=None,
+        **kwargs):
 
     """ Creates data/synthetics comparison figure with 3 columns (Z, R, T)
     """
@@ -82,11 +83,11 @@ def plot_waveforms1(
         _plot_stream(axes[ir], [1,2,3], ['Z','R','T'],
                   data[_i], synthetics[_i],
                   normalize, factor, trace_label_writer, total_misfit,
-                  syn_color=syn_color)
+                  dat_kwargs=dat_kwargs, syn_kwargs=syn_kwargs)
 
         ir += 1
 
-    _save(filename)
+    _save(filename, **kwargs)
     pyplot.close()
 
 
@@ -105,8 +106,9 @@ def plot_waveforms2(
         normalize='maximum_amplitude',
         trace_label_writer=trace_label_writer,
         station_label_writer=station_label_writer,
-        syn_color='red',
-        ):
+        dat_kwargs=None,
+        syn_kwargs=None,
+        **kwargs):
 
 
     """ Creates data/synthetics comparison figure with 5 columns 
@@ -165,17 +167,17 @@ def plot_waveforms2(
         _plot_stream(axes[ir], [1,2], ['Z','R'],
                      data_bw[_i], synthetics_bw[_i],
                      normalize, factor_bw, trace_label_writer, total_misfit_bw,
-                     syn_color=syn_color)
+                     dat_kwargs=dat_kwargs, syn_kwargs=syn_kwargs)
 
         # plot surface wave traces
         _plot_stream(axes[ir], [3,4,5], ['Z','R','T'],
                      data_sw[_i], synthetics_sw[_i],
                      normalize, factor_sw, trace_label_writer, total_misfit_sw,
-                     syn_color=syn_color)
+                     dat_kwargs=dat_kwargs, syn_kwargs=syn_kwargs)
 
         ir += 1
 
-    _save(filename)
+    _save(filename, **kwargs)
     pyplot.close()
 
 
@@ -196,8 +198,9 @@ def plot_waveforms3(
         normalize='maximum_amplitude',
         trace_label_writer=trace_label_writer,
         station_label_writer=station_label_writer,
-        syn_color='red',
-        ):
+        dat_kwargs=None,
+        syn_kwargs=None,
+        **kwargs):
 
     """ Creates data/synthetics comparison figure with 5 columns 
     (Pn Z, Pn R, Rayleigh Z, Rayleigh R, Love T)
@@ -268,23 +271,23 @@ def plot_waveforms3(
         _plot_stream(axes[ir], [1,2], ['Z','R'],
                      data_bw[_i], synthetics_bw[_i],
                      normalize, factor_bw, trace_label_writer, total_misfit_bw,
-                     syn_color=syn_color)
+                     dat_kwargs=dat_kwargs, syn_kwargs=syn_kwargs)
 
         # plot Rayleigh waves
         _plot_stream(axes[ir], [3,4], ['Z','R'],
                      data_rayl[_i], synthetics_rayl[_i],
                      normalize, factor_rayl, trace_label_writer, total_misfit_rayl,
-                     syn_color=syn_color)
+                     dat_kwargs=dat_kwargs, syn_kwargs=syn_kwargs)
 
         # plot Love waves
         _plot_stream(axes[ir], [5], ['T'],
                      data_love[_i], synthetics_love[_i],
                      normalize, factor_love, trace_label_writer, total_misfit_love,
-                     syn_color=syn_color)
+                     dat_kwargs=dat_kwargs, syn_kwargs=syn_kwargs)
 
         ir += 1
 
-    _save(filename)
+    _save(filename, **kwargs)
     pyplot.close()
 
 
@@ -318,11 +321,11 @@ def plot_data_greens1(
     else:
         model = _get_tag(greens[0].tags, 'model')
         solver = _get_tag(greens[0].tags, 'solver')
-        color = kwargs.pop('color', 'gray')
+        beachball_color = kwargs.pop('beachball_color', 'gray')
 
         header = _prepare_header(
             model, solver, source, source_dict, origin,
-            process_data, misfit, total_misfit, data_sw=data, color=color)
+            process_data, misfit, total_misfit, data_sw=data, beachball_color=beachball_color)
 
     plot_waveforms1(filename,
         data, synthetics, stations, origin,
@@ -373,13 +376,13 @@ def plot_data_greens2(filename,
     else:
         model = _get_tag(greens_sw[0].tags, 'model')
         solver = _get_tag(greens_sw[0].tags, 'solver')
-        color = kwargs.pop('color', 'gray')
+        beachball_color = kwargs.pop('beachball_color', 'gray')
 
         header = _prepare_header(
             model, solver, source, source_dict, origin,
             process_data_bw, process_data_sw,
             misfit_bw, misfit_sw, total_misfit_bw, total_misfit_sw,
-            data_bw=data_bw, data_sw=data_sw, color=color)
+            data_bw=data_bw, data_sw=data_sw, beachball_color=beachball_color)
 
     plot_waveforms2(filename,
         data_bw, data_sw, synthetics_bw, synthetics_sw, stations, origin,
@@ -439,14 +442,14 @@ def plot_data_greens3(
     else:
         model = _get_tag(greens_bw[0].tags, 'model')
         solver = _get_tag(greens_bw[0].tags, 'solver')
-        color = kwargs.pop('color', 'gray')
+        beachball_color = kwargs.pop('beachball_color', 'gray')
 
         header = _prepare_header(
             model, solver, source, source_dict, origin,
             process_data_bw, process_data_rayl, misfit_bw, misfit_rayl,
             total_misfit_bw, total_misfit_rayl, best_misfit_sw_supp=total_misfit_love,
             misfit_sw_supp = misfit_love, data_bw=data_bw, data_sw=data_rayl,
-            data_sw_supp=data_love, process_sw_supp=process_data_love, color=color)
+            data_sw_supp=data_love, process_sw_supp=process_data_love, beachball_color=beachball_color)
 
     plot_waveforms3(filename,
         data_bw, data_rayl, data_love,
@@ -547,7 +550,8 @@ def _plot_stream(
     amplitude_factor=None,
     trace_label_writer=None,
     total_misfit=1.,
-    syn_color='red',
+    dat_kwargs=None,
+    syn_kwargs=None,
     ):
 
     if normalize in [
@@ -593,7 +597,8 @@ def _plot_stream(
         elif amplitude_factor:
             ylim = [-amplitude_factor, +amplitude_factor]
 
-        _plot_trace(axis, dat, syn, syn_color=syn_color)
+        _plot_trace(axis, dat, syn,
+                    dat_kwargs=dat_kwargs, syn_kwargs=syn_kwargs)
 
         try:
             axis.set_ylim(*ylim)
@@ -606,18 +611,25 @@ def _plot_stream(
             pass
 
 
-def _plot_trace(axis, dat, syn, label=None, syn_color='red'):
+def _plot_trace(axis, dat, syn, dat_kwargs=None, syn_kwargs=None):
     """ Plots data and synthetics time series on current axes
     """
     if dat is None and syn is None:
         # nothing to plot
         return
 
+    _dat_kwargs = {'color': 'black', 'linewidth': 1.5, 'clip_on': True, 'zorder': 10}
+    if dat_kwargs:
+        _dat_kwargs.update(dat_kwargs)
+
+    _syn_kwargs = {'color': 'red', 'linewidth': 1.25, 'clip_on': True, 'zorder': 10}
+    if syn_kwargs:
+        _syn_kwargs.update(syn_kwargs)
+
     if dat:
         t,d = _time_series(dat)
 
-        axis.plot(t, d, 'k', linewidth=1.5,
-            clip_on=True, zorder=10)
+        axis.plot(t, d, **_dat_kwargs)
 
     if syn:
         # which start and stop indices will correctly align synthetics?
@@ -626,8 +638,7 @@ def _plot_trace(axis, dat, syn, label=None, syn_color='red'):
 
         t,s = _time_series(syn)
 
-        axis.plot(t[:stop-start], s[start:stop], color=syn_color, linewidth=1.25,
-            clip_on=True, zorder=10)
+        axis.plot(t[:stop-start], s[start:stop], **_syn_kwargs)
 
 
 
@@ -791,8 +802,8 @@ def _prepare_header(model, solver, source, source_dict, origin, *args, **kwargs)
         raise TypeError
 
 
-def _save(filename):
-    pyplot.savefig(filename)
+def _save(filename, **kwargs):
+    pyplot.savefig(filename, **kwargs)
 
 
 def _get_tag(tags, pattern):

--- a/mtuq/io/__init__.py
+++ b/mtuq/io/__init__.py
@@ -1,10 +1,10 @@
 
-from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points
 
 
 def _greens_databases():
     databases = {}
-    for entry_point in iter_entry_points('greens_databases'):
+    for entry_point in entry_points('greens_databases'):
         databases[entry_point.name] = entry_point.load()
     return databases
 

--- a/mtuq/process_data.py
+++ b/mtuq/process_data.py
@@ -295,8 +295,7 @@ class ProcessData(object):
             assert 'group_velocity' in parameters
             assert parameters['group_velocity'] >= 0.
             self.group_velocity = parameters['group_velocity']
-            self.window_alignment = getattr(
-                parameters, 'window_alignment', 0.5)
+            self.window_alignment = parameters.get('window_alignment', 0.5)
             assert 0. <= self.window_alignment <= 1.
             assert window_length > 0.
             self.window_length = window_length
@@ -321,10 +320,10 @@ class ProcessData(object):
             assert self.window_type is not None
 
         if apply_padding:
-            assert self.time_shift_min <= 0., \
+            assert time_shift_min <= 0., \
                 ValueError("Bad parameter: time_shift_min")
 
-            assert self.time_shift_max >= 0., \
+            assert time_shift_max >= 0., \
                 ValueError("Bad parameter: time_shift_max")
 
             self.time_shift_min = time_shift_min

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "nose",
   "pytest",
   "cython",
-  "setuptools<82",
+  "setuptools",
   "seisgen",
   "seisclient",
 ]

--- a/setup/code_generator.py
+++ b/setup/code_generator.py
@@ -1767,6 +1767,125 @@ Main_BenchmarkCAP="""
 """
 
 
+Imports_DirectEvaluation="""
+import os
+import numpy as np
+
+from mtuq import read, download_greens
+from mtuq.event import MomentTensor, Origin
+from mtuq.graphics import plot_data_greens2, plot_beachball
+from mtuq.misfit import Misfit
+from mtuq.process_data import ProcessData
+from mtuq.util import fullpath, merge_dicts, save_json
+from mtuq.util.cap import parse_station_codes, Trapezoid
+from mtuq.util.math import from_mij, to_mij, to_rho
+
+"""
+
+
+Docstring_DirectEvaluation="""
+if __name__=='__main__':
+    #
+    # Helper code for evaluating synthetic waveforms for a single fixed source.
+    #
+    # USAGE
+    #   python DirectEvaluation.py
+    #
+
+"""
+
+
+SourceDefinition_DirectEvaluation="""
+    #
+    # Define the source directly from moment tensor components (Mrr, Mtt, Mpp, Mrt, Mrp, Mtp).
+    # Alternatively, fault geometry can be converted using to_mij (see commented block below).
+    #
+
+    mt_dict = {
+        'Mrr': -5800435174432632.0,
+        'Mtt':   789342714264084.5,
+        'Mpp':  5011092460168549.0,
+        'Mrt':  3034156721905327.0,
+        'Mrp':  2110077787951300.2,
+        'Mtp':  2602039428905879.0,
+        }
+
+    mt_array = list(mt_dict.values())
+
+    # To define the source from fault geometry instead:
+    # Mw, strike, dip, rake = 4.5, 230., 40., -10.
+    # mt_array = to_mij(to_rho(Mw), 0., 0., strike, rake, np.cos(np.deg2rad(dip)))
+
+    lune_dict = dict(zip(('rho', 'v', 'w', 'kappa', 'sigma', 'h'), from_mij(mt_array)))
+
+    mt = MomentTensor(mt_array)
+
+    wavelet = Trapezoid(magnitude=4.5)
+
+"""
+
+
+Main_DirectEvaluation="""
+    #
+    # The main I/O work starts now
+    #
+
+    print('Reading data...\\n')
+    data = read(path_data, format='sac',
+        event_id=event_id,
+        station_id_list=station_id_list,
+        tags=['units:m', 'type:velocity'])
+
+    data.sort_by_distance()
+    stations = data.get_stations()
+
+    print('Processing data...\\n')
+    data_bw = data.map(process_bw)
+    data_sw = data.map(process_sw)
+
+    print('Reading Greens functions...\\n')
+    greens = download_greens(stations, origin, model)
+
+    print('Processing Greens functions...\\n')
+    greens.convolve(wavelet)
+    greens_bw = greens.map(process_bw)
+    greens_sw = greens.map(process_sw)
+
+
+    #
+    # Generating synthetics
+    #
+
+    syn_bw = greens_bw.get_synthetics(mt, components=['Z', 'R'])
+    syn_sw = greens_sw.get_synthetics(mt, components=['Z', 'R', 'T'])
+
+    syn_bw.write(event_id+'DC_synthetics_bw.sac', format='sac')
+    syn_sw.write(event_id+'DC_synthetics_sw.sac', format='sac')
+
+"""
+
+
+WrapUp_DirectEvaluation="""
+    print('Generating figures...\\n')
+
+    plot_data_greens2(event_id+'DC_waveforms.png',
+        data_bw, data_sw, greens_bw, greens_sw, process_bw, process_sw,
+        misfit_bw, misfit_sw, stations, origin, mt, lune_dict)
+
+    plot_beachball(event_id+'DC_beachball.png',
+        mt, stations, origin)
+
+
+    print('Saving results...\\n')
+
+    mt_dict.update(lune_dict)
+    mt_dict.update({'Mw': mt.magnitude(), 'M0': mt.moment()})
+    save_json(event_id+'DC_solution.json', mt_dict)
+
+    print('\\nFinished\\n')
+"""
+
+
 if __name__=='__main__':
     import os
     from mtuq.util import basepath, replace
@@ -1974,6 +2093,24 @@ if __name__=='__main__':
         file.write(Main1_SerialGridSearch_DoubleCouple)
         file.write(Main2_SerialGridSearch_DoubleCouple)
         file.write(WrapUp_SerialGridSearch_DoubleCouple)
+
+
+    with open('examples/DirectEvaluation.py', 'w') as file:
+        file.write("#!/usr/bin/env python\n")
+        file.write(Imports_DirectEvaluation)
+        file.write(Docstring_DirectEvaluation)
+        file.write(Paths_Syngine)
+        file.write(DataProcessingComments)
+        file.write(DataProcessingDefinitions)
+        file.write(MisfitComments)
+        file.write(MisfitDefinitions)
+        file.write(WeightsComments)
+        file.write(WeightsDefinitions)
+        file.write(SourceDefinition_DirectEvaluation)
+        file.write(OriginComments)
+        file.write(OriginDefinitions)
+        file.write(Main_DirectEvaluation)
+        file.write(WrapUp_DirectEvaluation)
 
 
     with open('examples/Waveforms+Polarities.py', 'w') as file:


### PR DESCRIPTION
I am combing through some of the open issues to try to address them.

### Addressing issues:

This small PR has no major theme be covers issues:
- #344 
- #334 
- #317 -> **kwarg support for savefig added to the waveform plot.
- #316 -> Added support for modifying both the beachball color and synthetic colors with **kwargs: `color` and `syn_color`:
<img width="1009" height="590" alt="image" src="https://github.com/user-attachments/assets/03cc44e1-4b38-4d09-8925-606281c476cf" />
this one being generated with following arguments:

```python3
beachball_color='red', dat_kwargs={'color': 'gray'}, syn_kwargs={'color': 'blue', 'linestyle': '--'}
```
This particular fix took some cues from PR #331 that has never been finalized. 
-----

### Other changes:

I also took the liberty to update the way we discover entry point by replacing use pkg_resources which was locking us into `setuptools<82`, the code now use `importlib.metadata`'s `entry_points`. This does not modify behaviors, but will remove deprecation warning when using `setup.py`:

```bash
UserWarning: pkg_resources is deprecated as an API. 
See https://setuptools.pypa.io/en/latest/pkg_resources.html. 
The pkg_resources package is slated for removal as early as 2025-11-30. 
Refrain from using this package or pin to Setuptools<81.
```


I also added a new dedicated example for the forward evaluation to address the following issue:

- #315 -> added a forward evaluation example.

It follow more or less the example script that was provided by @rmodrak in the issue's discussion, with its associated code generator and documentation entry.