### PR TITLE
Re-added CPS_metadata handling with cleaner implementation.

### DIFF
--- a/mtuq/greens_tensor/CPS.py
+++ b/mtuq/greens_tensor/CPS.py
@@ -7,7 +7,7 @@ from mtuq.greens_tensor.base import GreensTensor as GreensTensorBase
 
 class GreensTensor(GreensTensorBase):
     """
-    FK Green's tensor object
+    CPS Green's tensor object
 
     Overloads base class with machinery for working with CPS-style
     Green's functions

--- a/mtuq/process_data.py
+++ b/mtuq/process_data.py
@@ -72,6 +72,9 @@ class ProcessData(object):
     - ``'FK_metadata'``
       reads P, S travel times from FK metadata
 
+    - ``'CPS_metadata'``
+      reads P, S travel times from CPS database SAC headers
+
     - ``'SAC_metadata'``
       reads P, S travel times from SAC metadata fields `t5`, `t6`
 
@@ -148,8 +151,15 @@ class ProcessData(object):
     ``FK_database`` (`str`)
     Path to FK database, required for `pick_type=FK_metadata`
 
+    ``FK_model`` (`str`)
+    FK model name, optional for `pick_type=FK_metadata`
+
     ``CPS_database`` (`str`)
     Path to CPS database, required for `pick_type=CPS_metadata`
+
+    ``CPS_model`` (`str`)
+    CPS model name (subdirectory of `CPS_database`), optional for `pick_type=CPS_metadata`.
+    If `CPS_database` already ends with the model subdirectory, omit this argument.
 
     ``capuaf_file`` (`str`)
     Path to `CAPUAF`-style text file, required for `pick_type=user_supplied`
@@ -354,6 +364,18 @@ class ProcessData(object):
 
             self.FK_database = FK_database
             self.FK_model = FK_model
+
+        elif self.pick_type == 'CPS_metadata':
+            assert CPS_database is not None
+            assert exists(CPS_database)
+            if CPS_model is not None and \
+                    basename(CPS_database.rstrip('/')) == CPS_model:
+                warn("CPS_model '%s' is already the last component of "
+                     "CPS_database '%s'; setting CPS_model=None to avoid "
+                     "path duplication" % (CPS_model, CPS_database))
+                CPS_model = None
+            self.CPS_database = CPS_database
+            self.CPS_model = CPS_model  # may be None if model is specified in CPS_database path
 
         elif self.pick_type == 'SAC_metadata':
             pass
@@ -579,6 +601,37 @@ class ProcessData(object):
 
             elif self.pick_type == 'CPS_metadata':
                 raise NotImplemented
+                # base directory: CPS_model may be None if model is specified in CPS_database path
+                if self.CPS_model is not None:
+                    base_dir = join(self.CPS_database, self.CPS_model)
+                else:
+                    base_dir = self.CPS_database
+
+                # find depth folder closest to origin depth
+                # folder names encode depth as int(depth_km * 10), zero-padded to 4 digits
+                dep_desired = int(round(origin.depth_in_m / 100.))
+                depth_folders = [e for e in listdir(base_dir)
+                                 if isdir(join(base_dir, e)) and e.isdigit()]
+                dep_folder = min(depth_folders,
+                                 key=lambda x: abs(int(x) - dep_desired))
+
+                # same as above for distance file, closest to station distance
+                # filename prefix encodes distance as int(dist_km * 10), zero-padded to 5 digits
+                dst_desired = int(round(distance_in_m / 100.))
+                folder_path = join(base_dir, dep_folder)
+                dep_len = len(dep_folder)
+                dst_values = list({f.split('.')[0][:-dep_len]
+                                   for f in listdir(folder_path)
+                                   if f.endswith('.ZDD')})
+                dst_value = min(dst_values,
+                                key=lambda x: abs(int(x) - dst_desired))
+
+                sac_headers = obspy.read(
+                    join(folder_path, dst_value + dep_folder + '.ZDD'),
+                    format='sac')[0].stats.sac
+
+                picks['P'] = float(sac_headers.a) # Not sure if universal CPS convention, but compatible with CPS database in HiBasin examples
+                picks['S'] = float(sac_headers.t0) # same as above
 
             elif self.pick_type == 'SAC_metadata':
                 sac_headers = traces[0].sac

--- a/mtuq/process_data.py
+++ b/mtuq/process_data.py
@@ -600,7 +600,6 @@ class ProcessData(object):
                 picks['S'] = float(sac_headers.t2)
 
             elif self.pick_type == 'CPS_metadata':
-                raise NotImplemented
                 # base directory: CPS_model may be None if model is specified in CPS_database path
                 if self.CPS_model is not None:
                     base_dir = join(self.CPS_database, self.CPS_model)


### PR DESCRIPTION
This commit re-integrates the CPS-based ProcessData handling of Green's functions. It mimic the FK implementation, and try to handle gracefully possible confusion with database and model paths.

I have adopted conventions for CPS metadata based on HiBasin examples (P and S arrival in sac.a and sac.t0 fields). As stated in issue #336, not sure if this is universally accepted, but it is working with @Jinyin-Hu HiBasin examples.

I decided to also have the CPS_model argument (as in FK), just in case people might have several models in the same Database folder. Could remove if not likely given default CPS outputs style.

Also fix a misleading docstrings in `CPS.py`

Should address some of the issues encountered in #336 

> [!WARNING]  
> as of May 20th 2026, the CPS GF Databases in the [HiBasin](https://github.com/mtuqorg/HiBasin) repo are currently in displacement unit (m) and NOT in m/s, as expected by the default MTUQ readers. 
> Will remove when @Jinyin-Hu updates [HiBasin](https://github.com/mtuqorg/HiBasin)